### PR TITLE
[Feature] - [Login] 카카오/네이버 소셜 로그인 구현했습니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,6 @@ ext {
     set('snippetsDir', file("build/generated-snippets"))
 }
 
-ext['spring-security.version'] = '6.2.1'
-
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ ext {
 	set('snippetsDir', file("build/generated-snippets"))
 }
 
+ext['spring-security.version']='6.2.1'
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -1,66 +1,68 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.7'
-	id 'io.spring.dependency-management' version '1.1.4'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.7'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.coverflow'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	asciidoctorExtentions
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    asciidoctorExtentions
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
-ext['spring-security.version']='6.2.1'
+ext['spring-security.version'] = '6.2.1'
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation:3.1.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.1.2'
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	asciidoctorExtentions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExtentions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
-asciidoctor{
-	dependsOn test
-	configurations 'asciidoctorExtentions'
+asciidoctor {
+    dependsOn test
+    configurations 'asciidoctorExtentions'
 }
 
 tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+    inputs.dir snippetsDir
+    dependsOn test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation:3.1.2'
 
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/coverflow/config/SecurityConfig.java
+++ b/src/main/java/com/coverflow/config/SecurityConfig.java
@@ -1,7 +1,0 @@
-package com.coverflow.config;
-
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class SecurityConfig {
-}

--- a/src/main/java/com/coverflow/config/SecurityConfig.java
+++ b/src/main/java/com/coverflow/config/SecurityConfig.java
@@ -1,0 +1,7 @@
+package com.coverflow.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+}

--- a/src/main/java/com/coverflow/config/test.java
+++ b/src/main/java/com/coverflow/config/test.java
@@ -1,4 +1,0 @@
-package com.coverflow.config;
-
-public class test {
-}

--- a/src/main/java/com/coverflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/coverflow/global/config/SecurityConfig.java
@@ -1,32 +1,119 @@
 package com.coverflow.global.config;
 
+import com.coverflow.global.jwt.filter.JwtAuthenticationFilter;
+import com.coverflow.global.jwt.service.JwtService;
+import com.coverflow.global.login.filter.CustomJsonUsernamePasswordAuthenticationFilter;
+import com.coverflow.global.login.handler.LoginFailureHandler;
+import com.coverflow.global.login.handler.LoginSuccessHandler;
+import com.coverflow.global.login.service.LoginService;
+import com.coverflow.global.oauth2.handler.OAuth2LoginFailureHandler;
+import com.coverflow.global.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.coverflow.global.oauth2.service.CustomOAuth2UserService;
+import com.coverflow.member.domain.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.Customizer;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+@Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
-    private final String[] ALLOWED_URIS = {"/api/auth/**", "/api/oauth/**", "/api/find-corporation-list"};
+    private final String[] ALLOWED_URIS = {"/", "/api/auth/**", "/api/oauth/**", "/api/find-corporation-list"};
+    private final LoginService loginService;
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+    private final ObjectMapper objectMapper;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests(request ->
+        http
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(request ->
                         request.requestMatchers(ALLOWED_URIS).permitAll()
                                 .anyRequest().authenticated())
-                .oauth2Login(Customizer.withDefaults());
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler)
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                );
+//                .oauth2Login()
+//                .successHandler(oAuth2LoginSuccessHandler) // 동의하고 계속하기를 눌렀을 때 Handler 설정
+//                .failureHandler(oAuth2LoginFailureHandler) // 소셜 로그인 실패 시 핸들러 설정
+//                .userInfoEndpoint().userService(customOAuth2UserService); // customUserService 설정;
 
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    /**
+     * AuthenticationManager 설정 후 등록
+     * PasswordEncoder를 사용하는 AuthenticationProvider 지정 (PasswordEncoder는 위에서 등록한 PasswordEncoder 사용)
+     * FormLogin(기존 스프링 시큐리티 로그인)과 동일하게 DaoAuthenticationProvider 사용
+     * UserDetailsService는 커스텀 LoginService로 등록
+     * 또한, FormLogin과 동일하게 AuthenticationManager로는 구현체인 ProviderManager 사용(return ProviderManager)
+     */
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setPasswordEncoder(passwordEncoder());
+        provider.setUserDetailsService(loginService);
+        return new ProviderManager(provider);
+    }
+
+    /**
+     * 로그인 성공 시 호출되는 LoginSuccessJWTProviderHandler 빈 등록
+     */
+    @Bean
+    public LoginSuccessHandler loginSuccessHandler() {
+        return new LoginSuccessHandler(jwtService, memberRepository);
+    }
+
+    /**
+     * 로그인 실패 시 호출되는 LoginFailureHandler 빈 등록
+     */
+    @Bean
+    public LoginFailureHandler loginFailureHandler() {
+        return new LoginFailureHandler();
+    }
+
+    /**
+     * CustomJsonUsernamePasswordAuthenticationFilter 빈 등록
+     * 커스텀 필터를 사용하기 위해 만든 커스텀 필터를 Bean으로 등록
+     * setAuthenticationManager(authenticationManager())로 위에서 등록한 AuthenticationManager(ProviderManager) 설정
+     * 로그인 성공 시 호출할 handler, 실패 시 호출할 handler로 위에서 등록한 handler 설정
+     */
+    @Bean
+    public CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordAuthenticationFilter() {
+        CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordLoginFilter
+                = new CustomJsonUsernamePasswordAuthenticationFilter(objectMapper);
+        customJsonUsernamePasswordLoginFilter.setAuthenticationManager(authenticationManager());
+        customJsonUsernamePasswordLoginFilter.setAuthenticationSuccessHandler(loginSuccessHandler());
+        customJsonUsernamePasswordLoginFilter.setAuthenticationFailureHandler(loginFailureHandler());
+        return customJsonUsernamePasswordLoginFilter;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtService, memberRepository);
     }
 
 }

--- a/src/main/java/com/coverflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/coverflow/global/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.coverflow.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final String[] ALLOWED_URIS = {"/api/auth/**", "/api/oauth/**", "/api/find-corporation-list"};
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(request ->
+                        request.requestMatchers(ALLOWED_URIS).permitAll()
+                                .anyRequest().authenticated())
+                .oauth2Login(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/coverflow/global/entity/BaseEntity.java
+++ b/src/main/java/com/coverflow/global/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.coverflow.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String updatedBy;
+}

--- a/src/main/java/com/coverflow/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/coverflow/global/entity/BaseTimeEntity.java
@@ -1,0 +1,34 @@
+package com.coverflow.global.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime modifiedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        modifiedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 @Slf4j
-public class JwtAuthentificationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     /**
      * Jwt 인증 필터

--- a/src/main/java/com/coverflow/global/jwt/filter/JwtAuthentificationFilter.java
+++ b/src/main/java/com/coverflow/global/jwt/filter/JwtAuthentificationFilter.java
@@ -1,0 +1,162 @@
+package com.coverflow.global.jwt.filter;
+
+import com.coverflow.global.jwt.service.JwtService;
+import com.coverflow.global.util.PasswordUtil;
+import com.coverflow.member.domain.Member;
+import com.coverflow.member.domain.MemberRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthentificationFilter extends OncePerRequestFilter {
+
+    /**
+     * Jwt 인증 필터
+     * "/login" 이외의 URI 요청이 왔을 때 처리하는 필터
+     * <p>
+     * 기본적으로 사용자는 요청 헤더에 AccessToken만 담아서 요청
+     * AccessToken 만료 시에만 RefreshToken을 요청 헤더에 AccessToken과 함께 요청
+     * <p>
+     * 1. RefreshToken이 없고, AccessToken이 유효한 경우 -> 인증 성공 처리, RefreshToken을 재발급하지는 않는다.
+     * 2. RefreshToken이 없고, AccessToken이 없거나 유효하지 않은 경우 -> 인증 실패 처리, 403 ERROR
+     * 3. RefreshToken이 있는 경우 -> DB의 RefreshToken과 비교하여 일치하면 AccessToken 재발급, RefreshToken 재발급(RTR 방식)
+     * 인증 성공 처리는 하지 않고 실패 처리
+     */
+
+
+    private static final String NO_CHECK_URL = "/login"; // "/login"으로 들어오는 요청은 Filter 작동 X
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().equals(NO_CHECK_URL)) {
+            filterChain.doFilter(request, response); // "/login" 요청이 들어오면, 다음 필터 호출
+            return; // return으로 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행시킴)
+        }
+
+        // 사용자 요청 헤더에서 RefreshToken 추출
+        // -> RefreshToken이 없거나 유효하지 않다면(DB에 저장된 RefreshToken과 다르다면) null을 반환
+        // 사용자의 요청 헤더에 RefreshToken이 있는 경우는, AccessToken이 만료되어 요청한 경우밖에 없다.
+        // 따라서, 위의 경우를 제외하면 추출한 refreshToken은 모두 null
+        String refreshToken = jwtService.extractRefreshToken(request)
+                .filter(jwtService::isTokenValid)
+                .orElse(null);
+
+        // 리프레시 토큰이 요청 헤더에 존재했다면, 사용자가 AccessToken이 만료되어서
+        // RefreshToken까지 보낸 것이므로 리프레시 토큰이 DB의 리프레시 토큰과 일치하는지 판단 후,
+        // 일치한다면 AccessToken을 재발급해준다.
+        if (refreshToken != null) {
+            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+            return; // RefreshToken을 보낸 경우에는 AccessToken을 재발급 하고 인증 처리는 하지 않게 하기위해 바로 return으로 필터 진행 막기
+        }
+
+        // RefreshToken이 없거나 유효하지 않다면, AccessToken을 검사하고 인증을 처리하는 로직 수행
+        // AccessToken이 없거나 유효하지 않다면, 인증 객체가 담기지 않은 상태로 다음 필터로 넘어가기 때문에 403 에러 발생
+        // AccessToken이 유효하다면, 인증 객체가 담긴 상태로 다음 필터로 넘어가기 때문에 인증 성공
+        if (refreshToken == null) {
+            checkAccessTokenAndAuthentication(request, response, filterChain);
+        }
+    }
+
+    /**
+     * [리프레시 토큰으로 유저 정보 찾기 & 액세스 토큰/리프레시 토큰 재발급 메소드]
+     * 파라미터로 들어온 헤더에서 추출한 리프레시 토큰으로 DB에서 유저를 찾고, 해당 유저가 있다면
+     * JwtService.createAccessToken()으로 AccessToken 생성,
+     * reIssueRefreshToken()로 리프레시 토큰 재발급 & DB에 리프레시 토큰 업데이트 메소드 호출
+     * 그 후 JwtService.sendAccessTokenAndRefreshToken()으로 응답 헤더에 보내기
+     */
+    public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+        memberRepository.findByRefreshToken(refreshToken)
+                .ifPresent(user -> {
+                    String reIssuedRefreshToken = reIssueRefreshToken(user);
+                    jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getEmail()),
+                            reIssuedRefreshToken);
+                });
+    }
+
+    /**
+     * [리프레시 토큰 재발급 & DB에 리프레시 토큰 업데이트 메소드]
+     * jwtService.createRefreshToken()으로 리프레시 토큰 재발급 후
+     * DB에 재발급한 리프레시 토큰 업데이트 후 Flush
+     */
+    private String reIssueRefreshToken(Member member) {
+        String reIssuedRefreshToken = jwtService.createRefreshToken();
+        member.updateRefreshToken(reIssuedRefreshToken);
+        memberRepository.saveAndFlush(member);
+        return reIssuedRefreshToken;
+    }
+
+    /**
+     * [액세스 토큰 체크 & 인증 처리 메소드]
+     * request에서 extractAccessToken()으로 액세스 토큰 추출 후, isTokenValid()로 유효한 토큰인지 검증
+     * 유효한 토큰이면, 액세스 토큰에서 extractEmail로 Email을 추출한 후 findByEmail()로 해당 이메일을 사용하는 유저 객체 반환
+     * 그 유저 객체를 saveAuthentication()으로 인증 처리하여
+     * 인증 허가 처리된 객체를 SecurityContextHolder에 담기
+     * 그 후 다음 인증 필터로 진행
+     */
+    public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                                  FilterChain filterChain) throws ServletException, IOException {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtService.extractAccessToken(request)
+                .filter(jwtService::isTokenValid)
+                .ifPresent(accessToken -> jwtService.extractEmail(accessToken)
+                        .ifPresent(email -> memberRepository.findByEmail(email)
+                                .ifPresent(this::saveAuthentication)));
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * [인증 허가 메소드]
+     * 파라미터의 유저 : 우리가 만든 회원 객체 / 빌더의 유저 : UserDetails의 User 객체
+     * <p>
+     * new UsernamePasswordAuthenticationToken()로 인증 객체인 Authentication 객체 생성
+     * UsernamePasswordAuthenticationToken의 파라미터
+     * 1. 위에서 만든 UserDetailsUser 객체 (유저 정보)
+     * 2. credential(보통 비밀번호로, 인증 시에는 보통 null로 제거)
+     * 3. Collection < ? extends GrantedAuthority>로,
+     * UserDetails의 User 객체 안에 Set<GrantedAuthority> authorities이 있어서 getter로 호출한 후에,
+     * new NullAuthoritiesMapper()로 GrantedAuthoritiesMapper 객체를 생성하고 mapAuthorities()에 담기
+     * <p>
+     * SecurityContextHolder.getContext()로 SecurityContext를 꺼낸 후,
+     * setAuthentication()을 이용하여 위에서 만든 Authentication 객체에 대한 인증 허가 처리
+     */
+    public void saveAuthentication(Member myMember) {
+        String password = myMember.getPassword();
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
+            password = PasswordUtil.generateRandomPassword();
+        }
+
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(myMember.getEmail())
+                .password(password)
+                .roles(myMember.getRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+
+}

--- a/src/main/java/com/coverflow/global/jwt/service/JwtService.java
+++ b/src/main/java/com/coverflow/global/jwt/service/JwtService.java
@@ -1,0 +1,169 @@
+package com.coverflow.global.jwt.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.coverflow.member.domain.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Getter
+@Service
+public class JwtService {
+
+    /**
+     * JWT의 Subject와 Claim으로 email 사용 -> 클레임의 name을 "email"으로 설정
+     * JWT의 헤더에 들어오는 값 : 'Authorization(Key) = Bearer {토큰} (Value)' 형식
+     */
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String BEARER = "Bearer ";
+    private final MemberRepository memberRepository;
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    /**
+     * AccessToken 생성 메소드
+     */
+    public String createAccessToken(String email) {
+        Date now = new Date();
+        return JWT.create() // JWT 토큰을 생성하는 빌더 반환
+                .withSubject(ACCESS_TOKEN_SUBJECT) // JWT의 Subject 지정 -> AccessToken이므로 AccessToken
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod)) // 토큰 만료 시간 설정
+
+                //클레임으로는 저희는 email 하나만 사용합니다.
+                //추가적으로 식별자나, 이름 등의 정보를 더 추가하셔도 됩니다.
+                //추가하실 경우 .withClaim(클래임 이름, 클래임 값) 으로 설정해주시면 됩니다
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(secretKey)); // HMAC512 알고리즘 사용, application-jwt.yml에서 지정한 secret 키로 암호화
+    }
+
+    /**
+     * RefreshToken 생성
+     * RefreshToken은 Claim에 email도 넣지 않으므로 withClaim() X
+     */
+    public String createRefreshToken() {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    /**
+     * AccessToken 헤더에 실어서 보내기
+     */
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        response.setHeader(accessHeader, accessToken);
+        log.info("재발급된 Access Token : {}", accessToken);
+    }
+
+    /**
+     * AccessToken + RefreshToken 헤더에 실어서 보내기
+     */
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+        log.info("Access Token, Refresh Token 헤더 설정 완료");
+    }
+
+    /**
+     * 헤더에서 RefreshToken 추출
+     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
+     */
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * 헤더에서 AccessToken 추출
+     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * AccessToken에서 Email 추출
+     * 추출 전에 JWT.require()로 검증기 생성
+     * verify로 AceessToken 검증 후
+     * 유효하다면 getClaim()으로 이메일 추출
+     * 유효하지 않다면 빈 Optional 객체 반환
+     */
+    public Optional<String> extractEmail(String accessToken) {
+        try {
+            // 토큰 유효성 검사하는 데에 사용할 알고리즘이 있는 JWT verifier builder 반환
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                    .build() // 반환된 빌더로 JWT verifier 생성
+                    .verify(accessToken) // accessToken을 검증하고 유효하지 않다면 예외 발생
+                    .getClaim(EMAIL_CLAIM) // claim(Emial) 가져오기
+                    .asString());
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * AccessToken 헤더 설정
+     */
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+    /**
+     * RefreshToken 헤더 설정
+     */
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, refreshToken);
+    }
+
+    /**
+     * RefreshToken DB 저장(업데이트)
+     */
+    public void updateRefreshToken(String email, String refreshToken) {
+        memberRepository.findByEmail(email)
+                .ifPresentOrElse(
+                        user -> user.updateRefreshToken(refreshToken),
+                        () -> new Exception("일치하는 회원이 없습니다.")
+                );
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/coverflow/global/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -59,7 +59,6 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
      */
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
-        System.out.println("엉");
         if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
             throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
         }

--- a/src/main/java/com/coverflow/global/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package com.coverflow.global.login.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+
+/**
+ * 스프링 시큐리티의 폼 기반의 UsernamePasswordAuthenticationFilter를 참고하여 만든 커스텀 필터
+ * 거의 구조가 같고, Type이 Json인 Login만 처리하도록 설정한 부분만 다르다. (커스텀 API용 필터 구현)
+ * Username : 회원 아이디 -> email로 설정
+ * "/login" 요청 왔을 때 JSON 값을 매핑 처리하는 필터
+ */
+public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final String DEFAULT_LOGIN_REQUEST_URL = "/login"; // "/login"으로 오는 요청을 처리
+    private static final String HTTP_METHOD = "POST"; // 로그인 HTTP 메소드는 POST
+    private static final String CONTENT_TYPE = "application/json"; // JSON 타입의 데이터로 오는 로그인 요청만 처리
+    private static final String USERNAME_KEY = "email"; // 회원 로그인 시 이메일 요청 JSON Key : "email"
+    private static final String PASSWORD_KEY = "password"; // 회원 로그인 시 비밀번호 요청 JSon Key : "password"
+    private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
+            new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URL, HTTP_METHOD); // "/login" + POST로 온 요청에 매칭된다.
+
+    private final ObjectMapper objectMapper;
+
+    public CustomJsonUsernamePasswordAuthenticationFilter(ObjectMapper objectMapper) {
+        super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER); // 위에서 설정한 "login" + POST로 온 요청을 처리하기 위해 설정
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 인증 처리 메소드
+     * <p>
+     * UsernamePasswordAuthenticationFilter와 동일하게 UsernamePasswordAuthenticationToken 사용
+     * StreamUtils를 통해 request에서 messageBody(JSON) 반환
+     * 요청 JSON Example
+     * {
+     * "email" : "aaa@bbb.com"
+     * "password" : "test123"
+     * }
+     * 꺼낸 messageBody를 objectMapper.readValue()로 Map으로 변환 (Key : JSON의 키 -> email, password)
+     * Map의 Key(email, password)로 해당 이메일, 패스워드 추출 후
+     * UsernamePasswordAuthenticationToken의 파라미터 principal, credentials에 대입
+     * <p>
+     * AbstractAuthenticationProcessingFilter(부모)의 getAuthenticationManager()로 AuthenticationManager 객체를 반환 받은 후
+     * authenticate()의 파라미터로 UsernamePasswordAuthenticationToken 객체를 넣고 인증 처리
+     * (여기서 AuthenticationManager 객체는 ProviderManager -> SecurityConfig에서 설정)
+     */
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
+        if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
+            throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
+        }
+
+        String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+
+        Map<String, String> usernamePasswordMap = objectMapper.readValue(messageBody, Map.class);
+
+        String email = usernamePasswordMap.get(USERNAME_KEY);
+        String password = usernamePasswordMap.get(PASSWORD_KEY);
+
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);//principal 과 credentials 전달
+
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+}
+

--- a/src/main/java/com/coverflow/global/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -59,6 +59,7 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
      */
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
+        System.out.println("엉");
         if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
             throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
         }

--- a/src/main/java/com/coverflow/global/login/handler/LoginFailureHandler.java
+++ b/src/main/java/com/coverflow/global/login/handler/LoginFailureHandler.java
@@ -1,0 +1,27 @@
+package com.coverflow.global.login.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import java.io.IOException;
+
+/**
+ * JWT 로그인 실패 시 처리하는 핸들러
+ * SimpleUrlAuthenticationFailureHandler를 상속받아서 구현
+ */
+@Slf4j
+public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("text/plain;charset=UTF-8");
+        response.getWriter().write("로그인 실패! 이메일이나 비밀번호를 확인해주세요.");
+        log.info("로그인에 실패했습니다. 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/coverflow/global/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/coverflow/global/login/handler/LoginSuccessHandler.java
@@ -1,0 +1,47 @@
+package com.coverflow.global.login.handler;
+
+import com.coverflow.global.jwt.service.JwtService;
+import com.coverflow.member.domain.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    @Value("${jwt.access.expiration}")
+    private String accessTokenExpiration;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) {
+        String email = extractUsername(authentication); // 인증 정보에서 Username(email) 추출
+        String accessToken = jwtService.createAccessToken(email); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
+        String refreshToken = jwtService.createRefreshToken(); // JwtService의 createRefreshToken을 사용하여 RefreshToken 발급
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken); // 응답 헤더에 AccessToken, RefreshToken 실어서 응답
+
+        memberRepository.findByEmail(email)
+                .ifPresent(user -> {
+                    user.updateRefreshToken(refreshToken);
+                    memberRepository.saveAndFlush(user);
+                });
+        log.info("로그인에 성공하였습니다. 이메일 : {}", email);
+        log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
+        log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+    }
+
+    private String extractUsername(Authentication authentication) {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        return userDetails.getUsername();
+    }
+}

--- a/src/main/java/com/coverflow/global/login/service/LoginService.java
+++ b/src/main/java/com/coverflow/global/login/service/LoginService.java
@@ -1,0 +1,28 @@
+package com.coverflow.global.login.service;
+
+import com.coverflow.member.domain.Member;
+import com.coverflow.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LoginService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member user = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일이 존재하지 않습니다."));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password(user.getPassword())
+                .roles(user.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/coverflow/global/oauth2/CustomOAuth2User.java
@@ -1,0 +1,32 @@
+package com.coverflow.global.oauth2;
+
+import com.coverflow.member.domain.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private final String email;
+    private final Role role;
+
+    /**
+     * Constructs a {@code DefaultOAuth2User} using the provided parameters.
+     *
+     * @param authorities      the authorities granted to the user
+     * @param attributes       the attributes about the user
+     * @param nameAttributeKey the key used to access the user's "name" from
+     *                         {@link #getAttributes()}
+     */
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes, String nameAttributeKey,
+                            String email, Role role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/coverflow/global/oauth2/OAuthAttributes.java
@@ -1,0 +1,85 @@
+package com.coverflow.global.oauth2;
+
+import com.coverflow.global.oauth2.userinfo.GoogleOAuth2UserInfo;
+import com.coverflow.global.oauth2.userinfo.KakaoOAuth2UserInfo;
+import com.coverflow.global.oauth2.userinfo.NaverOAuth2UserInfo;
+import com.coverflow.global.oauth2.userinfo.OAuth2UserInfo;
+import com.coverflow.member.domain.Member;
+import com.coverflow.member.domain.Role;
+import com.coverflow.member.domain.SocialType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 각 소셜에서 받아오는 데이터가 다르므로
+ * 소셜별로 데이터를 받는 데이터를 분기 처리하는 DTO 클래스
+ */
+@Getter
+public class OAuthAttributes {
+
+    private final String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private final OAuth2UserInfo oauth2UserInfo; // 소셜 타입별 로그인 유저 정보(닉네임, 이메일, 프로필 사진 등등)
+
+    @Builder
+    private OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oauth2UserInfo = oauth2UserInfo;
+    }
+
+    /**
+     * SocialType에 맞는 메소드 호출하여 OAuthAttributes 객체 반환
+     * 파라미터 : userNameAttributeName -> OAuth2 로그인 시 키(PK)가 되는 값 / attributes : OAuth 서비스의 유저 정보들
+     * 소셜별 of 메소드(ofGoogle, ofKaKao, ofNaver)들은 각각 소셜 로그인 API에서 제공하는
+     * 회원의 식별값(id), attributes, nameAttributeKey를 저장 후 build
+     */
+    public static OAuthAttributes of(SocialType socialType,
+                                     String userNameAttributeName, Map<String, Object> attributes) {
+
+        if (socialType == SocialType.NAVER) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
+        if (socialType == SocialType.KAKAO) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new NaverOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    /**
+     * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+     * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+     * email에는 UUID로 중복 없는 랜덤 값 생성
+     * role은 GUEST로 설정
+     */
+    public Member toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+        return Member.builder()
+                .socialType(socialType)
+                .socialId(oauth2UserInfo.getId())
+                .email(UUID.randomUUID() + "@socialUser.com")
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/coverflow/global/oauth2/OAuthAttributes.java
@@ -70,7 +70,7 @@ public class OAuthAttributes {
 
     /**
      * of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
-     * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+     * OAuth2UserInfo에서 socialId(식별값)을 가져와서 build
      * email에는 UUID로 중복 없는 랜덤 값 생성
      * role은 GUEST로 설정
      */

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,19 @@
+package com.coverflow.global.oauth2.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,5 +1,8 @@
 package com.coverflow.global.oauth2.handler;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,54 @@
+package com.coverflow.global.oauth2.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공!");
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+            // User의 Role이 GUEST일 경우 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
+            if (oAuth2User.getRole() == Role.GUEST) {
+                String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+                response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+                response.sendRedirect("oauth2/sign-up"); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트
+
+                jwtService.sendAccessAndRefreshToken(response, accessToken, null);
+//                User findUser = userRepository.findByEmail(oAuth2User.getEmail())
+//                                .orElseThrow(() -> new IllegalArgumentException("이메일에 해당하는 유저가 없습니다."));
+//                findUser.authorizeUser();
+            } else {
+                loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
+            }
+        } catch (Exception e) {
+            throw e;
+        }
+
+    }
+
+    // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+        String refreshToken = jwtService.createRefreshToken();
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,5 +1,10 @@
 package com.coverflow.global.oauth2.handler;
 
+import com.coverflow.global.jwt.service.JwtService;
+import com.coverflow.global.oauth2.CustomOAuth2User;
+import com.coverflow.member.domain.Role;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -14,10 +19,9 @@ import java.io.IOException;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtService jwtService;
-    private final UserRepository userRepository;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         log.info("OAuth2 Login 성공!");
         try {
             CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
@@ -42,7 +46,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     }
 
     // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
-    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) {
         String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
         String refreshToken = jwtService.createRefreshToken();
         response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Component
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
-
     private final JwtService jwtService;
 
     @Override
@@ -42,7 +41,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         } catch (Exception e) {
             throw e;
         }
-
     }
 
     // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기

--- a/src/main/java/com/coverflow/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/coverflow/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,101 @@
+package com.coverflow.global.oauth2.service;
+
+import com.coverflow.global.oauth2.CustomOAuth2User;
+import com.coverflow.global.oauth2.OAuthAttributes;
+import com.coverflow.member.domain.Member;
+import com.coverflow.member.domain.MemberRepository;
+import com.coverflow.member.domain.SocialType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private static final String NAVER = "naver";
+    private static final String KAKAO = "kakao";
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        /**
+         * DefaultOAuth2UserService 객체를 생성하여, loadUser(userRequest)를 통해 DefaultOAuth2User 객체를 생성 후 반환
+         * DefaultOAuth2UserService의 loadUser()는 소셜 로그인 API의 사용자 정보 제공 URI로 요청을 보내서
+         * 사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환한다.
+         * 결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저
+         */
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        /**
+         * userRequest에서 registrationId 추출 후 registrationId으로 SocialType 저장
+         * http://localhost:8080/oauth2/authorization/kakao에서 kakao가 registrationId
+         * userNameAttributeName은 이후에 nameAttributeKey로 설정된다.
+         */
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialType socialType = getSocialType(registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName(); // OAuth2 로그인 시 키(PK)가 되는 값
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
+
+        // socialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
+        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+
+        Member createdMember = getMember(extractAttributes, socialType); // getMember() 메소드로 Member 객체 생성 후 반환
+
+        // DefaultOAuth2User를 구현한 CustomOAuth2User 객체를 생성해서 반환
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().getKey())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdMember.getEmail(),
+                createdMember.getRole()
+        );
+    }
+
+    private SocialType getSocialType(String registrationId) {
+        if (NAVER.equals(registrationId)) {
+            return SocialType.NAVER;
+        }
+        if (KAKAO.equals(registrationId)) {
+            return SocialType.KAKAO;
+        }
+        return SocialType.GOOGLE;
+    }
+
+    /**
+     * SocialType과 attributes에 들어있는 소셜 로그인의 식별값 id를 통해 회원을 찾아 반환하는 메소드
+     * 만약 찾은 회원이 있다면, 그대로 반환하고 없다면 saveUser()를 호출하여 회원을 저장한다.
+     */
+    private Member getMember(OAuthAttributes attributes, SocialType socialType) {
+        Member findMember = memberRepository.findBySocialTypeAndSocialId(socialType,
+                attributes.getOauth2UserInfo().getId()).orElse(null);
+
+        if (findMember == null) {
+            return saveMember(attributes, socialType);
+        }
+        return findMember;
+    }
+
+    /**
+     * OAuthAttributes의 toEntity() 메소드를 통해 빌더로 User 객체 생성 후 반환
+     * 생성된 User 객체를 DB에 저장 : socialType, socialId, email, role 값만 있는 상태
+     */
+    private Member saveMember(OAuthAttributes attributes, SocialType socialType) {
+        Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+        return memberRepository.save(createdMember);
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,15 @@
+package com.coverflow.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,15 @@
+package com.coverflow.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package com.coverflow.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+}

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,14 @@
+package com.coverflow.global.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId(); //소셜 식별 값 : 구글 - "sub", 카카오 - "id", 네이버 - "id"
+}

--- a/src/main/java/com/coverflow/global/util/PasswordUtil.java
+++ b/src/main/java/com/coverflow/global/util/PasswordUtil.java
@@ -1,0 +1,30 @@
+package com.coverflow.global.util;
+
+import java.util.Random;
+
+public class PasswordUtil {
+    public static String generateRandomPassword() {
+        int index = 0;
+        char[] charSet = new char[]{
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+        };    //배열안의 문자 숫자는 원하는대로
+
+        StringBuffer password = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 8; i++) {
+            double rd = random.nextDouble();
+            index = (int) (charSet.length * rd);
+
+            password.append(charSet[index]);
+        }
+        System.out.println(password);
+        return password.toString();
+        //StringBuffer를 String으로 변환해서 return 하려면 toString()을 사용하면 된다.
+    }
+}
+

--- a/src/main/java/com/coverflow/member/application/MemberService.java
+++ b/src/main/java/com/coverflow/member/application/MemberService.java
@@ -1,4 +1,40 @@
 package com.coverflow.member.application;
 
+import com.coverflow.member.domain.Member;
+import com.coverflow.member.domain.MemberRepository;
+import com.coverflow.member.domain.Role;
+import com.coverflow.member.dto.MemberSignUpDTO;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
 public class MemberService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signUp(MemberSignUpDTO memberSignUpDTO) throws Exception {
+
+        if (memberRepository.findByEmail(memberSignUpDTO.getEmail()).isPresent()) {
+            throw new Exception("이미 존재하는 이메일입니다.");
+        }
+
+        if (memberRepository.findByNickname(memberSignUpDTO.getNickname()).isPresent()) {
+            throw new Exception("이미 존재하는 닉네임입니다.");
+        }
+
+        Member member = Member.builder()
+                .email(memberSignUpDTO.getEmail())
+                .password(memberSignUpDTO.getPassword())
+                .nickname(memberSignUpDTO.getNickname())
+                .age(memberSignUpDTO.getAge())
+                .role(Role.MEMBER)
+                .build();
+
+        member.passwordEncode(passwordEncoder);
+        memberRepository.save(member);
+    }
 }

--- a/src/main/java/com/coverflow/member/domain/Member.java
+++ b/src/main/java/com/coverflow/member/domain/Member.java
@@ -1,26 +1,32 @@
 package com.coverflow.member.domain;
 
+import com.coverflow.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Builder
-public class Member {
+@Entity
+@Table(name = "tbl_member")
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "member_id")
     private UUID member_id;
-
     private String password;
     private String email;
+    private String nickname;
+    private String tag;
     private String gender;
     private int age;
-    private String nickname;
+    private String status;
+    private LocalDateTime lastLoginTime;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -32,10 +38,6 @@ public class Member {
 
     private String refreshToken; // 리프레시 토큰
 
-    public Member() {
-
-    }
-
     // 유저 권한 설정 메소드
     public void authorizeMember() {
         this.role = Role.MEMBER;
@@ -43,6 +45,18 @@ public class Member {
 
     public void passwordEncode(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);
+    }
+
+    public void updateNickname(String updateNickname) {
+        this.nickname = updateNickname;
+    }
+
+    public void updateAge(int updateAge) {
+        this.age = updateAge;
+    }
+
+    public void updatePassword(String updatePassword, PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(updatePassword);
     }
 
     public void updateRefreshToken(String updateRefreshToken) {

--- a/src/main/java/com/coverflow/member/domain/Member.java
+++ b/src/main/java/com/coverflow/member/domain/Member.java
@@ -1,4 +1,51 @@
 package com.coverflow.member.domain;
 
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Builder
 public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "member_id")
+    private UUID member_id;
+
+    private String password;
+    private String email;
+    private String gender;
+    private int age;
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType; // KAKAO, NAVER, GOOGLE
+
+    private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
+
+    private String refreshToken; // 리프레시 토큰
+
+    public Member() {
+
+    }
+
+    // 유저 권한 설정 메소드
+    public void authorizeMember() {
+        this.role = Role.MEMBER;
+    }
+
+    public void passwordEncode(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(this.password);
+    }
+
+    public void updateRefreshToken(String updateRefreshToken) {
+        this.refreshToken = updateRefreshToken;
+    }
 }

--- a/src/main/java/com/coverflow/member/domain/MemberRepository.java
+++ b/src/main/java/com/coverflow/member/domain/MemberRepository.java
@@ -1,0 +1,21 @@
+package com.coverflow.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
+
+    /**
+     * 소셜 타입과 소셜의 식별값으로 회원 찾는 메소드
+     * 정보 제공을 동의한 순간 DB에 저장해야하지만, 아직 추가 정보(사는 도시, 나이 등)를 입력받지 않았으므로
+     * 유저 객체는 DB에 있지만, 추가 정보가 빠진 상태이다.
+     * 따라서 추가 정보를 입력받아 회원 가입을 진행할 때 소셜 타입, 식별자로 해당 회원을 찾기 위한 메소드
+     */
+    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+}

--- a/src/main/java/com/coverflow/member/domain/MemberRepository.java
+++ b/src/main/java/com/coverflow/member/domain/MemberRepository.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 public interface MemberRepository extends JpaRepository<Member, UUID> {
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByNickname(String nickname);
+
     Optional<Member> findByRefreshToken(String refreshToken);
 
     /**

--- a/src/main/java/com/coverflow/member/domain/Role.java
+++ b/src/main/java/com/coverflow/member/domain/Role.java
@@ -1,0 +1,16 @@
+package com.coverflow.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    GUEST("ROLE_GUEST"),
+    MEMBER("ROLE_MEMBER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+}
+

--- a/src/main/java/com/coverflow/member/domain/Role.java
+++ b/src/main/java/com/coverflow/member/domain/Role.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-    GUEST("ROLE_GUEST"),
-    MEMBER("ROLE_MEMBER"),
-    ADMIN("ROLE_ADMIN");
+    GUEST("GUEST"),
+    MEMBER("MEMBER"),
+    ADMIN("ADMIN");
 
     private final String key;
 }

--- a/src/main/java/com/coverflow/member/domain/SocialType.java
+++ b/src/main/java/com/coverflow/member/domain/SocialType.java
@@ -1,0 +1,6 @@
+package com.coverflow.member.domain;
+
+public enum SocialType {
+    KAKAO, NAVER, GOOGLE
+}
+

--- a/src/main/java/com/coverflow/member/dto/MemberSignUpDTO.java
+++ b/src/main/java/com/coverflow/member/dto/MemberSignUpDTO.java
@@ -1,0 +1,13 @@
+package com.coverflow.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberSignUpDTO {
+    private String email;
+    private String password;
+    private String nickname;
+    private int age;
+}

--- a/src/main/java/com/coverflow/member/presentation/MemberController.java
+++ b/src/main/java/com/coverflow/member/presentation/MemberController.java
@@ -1,4 +1,26 @@
 package com.coverflow.member.presentation;
 
+import com.coverflow.member.application.MemberService;
+import com.coverflow.member.dto.MemberSignUpDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
 public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/sign-up")
+    public String signUp(@RequestBody MemberSignUpDTO memberSignUpDto) throws Exception {
+        memberService.signUp(memberSignUpDto);
+        return "회원가입 성공";
+    }
+
+    @GetMapping("/jwt-test")
+    public String jwtTest() {
+        return "jwtTest 요청 성공";
+    }
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,5 +6,9 @@
 </head>
 <body>
 Welcome to Spring Boot!
+<br>
+<a href="/oauth2/authorization/kakao">Kakao Login</a><br>
+<a href="/oauth2/authorization/google">Google Login</a><br>
+<a href="/oauth2/authorization/naver">Naver Login</a><br>
 </body>
 </html>


### PR DESCRIPTION
# ✨(#이슈 번호)
<!-- 이슈 번호는 꼭 함께 적어주세요. -->
* closed #4 

# ✏️내용
카카오/네이버 소셜 로그인 구현했습니다.

기술 스택:
- Spring Boot 3 + Spring Security 6 + OAuth2 + JWT + MySQL

사용자, 우리의 서비스(리액트+스프링부트), 카카오/네이버(인증 서버 및 리소스 서버)
1. 사용자가 우리의 서비스에 접속해서 카카오/네이버 로그인 버튼 누름
2. 우리 서비스는 카카오 인증 서버로 인가 코드를 요청
3. 카카오 서버로부터 인가 코드 받으면 그 인가 코드로 다시 액세스 토큰(사용자 정보) 요청
4-1. 카카오 액세스 토큰을 받으면 액세스 토큰으로부터 사용자 정보를 얻어내
4-2. 첫 회원일 경우 사용자 정보를 우리 DB(MySQL)에 저장함 => 회원가입
4-3. 기존 회원일 경우 DB에 있는 회원의 정보랑 비교해 스프링에서 우리 서버의 액세스+리프레쉬 토큰을 발급함
5. 스프링부트에서 리액트로 우리의 토큰을 보내주면 로그인 성공

아직 수정할 거 많아요

# 📸스크린샷
- 카카오 로그인 액세스 토큰 발급 결과(Response에 Authorization 부분)
![image](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/18030b54-0d2b-4716-9343-93f977b7906b)

- DB에 있는 카카오로 로그인 한 회원의 정보
![image](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/fb4c35dc-4939-4289-825d-1e8a962123b9)


- 네이버 로그인 액세스 토큰 발급 결과(Response에 Authorization 부분)
![image](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/667a4a88-a3c7-4ae6-856f-5fa61fd7631c)

- DB에 있는 네이버로 로그인 한 회원의 정보
![image](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/02ac786b-14de-450e-908d-32309e306d12)

# 🎁참고사항
