### PR TITLE
[BugFix] - [Login] 이중 조회 버그 수정했습니다.

### DIFF
--- a/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
@@ -63,7 +63,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 일치한다면 AccessToken을 재발급해준다.
         if (refreshToken != null) {
             log.info("리프레쉬 토큰 존재");
-            System.out.println("refreshToken = " + refreshToken);
             checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
             return; // RefreshToken을 보낸 경우에는 AccessToken을 재발급 하고 인증 처리는 하지 않게 하기위해 바로 return으로 필터 진행 막기
         }

--- a/src/main/java/com/coverflow/global/jwt/service/JwtService.java
+++ b/src/main/java/com/coverflow/global/jwt/service/JwtService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class JwtService {
      */
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
-    private static final String EMAIL_CLAIM = "email";
+    private static final String MEMBER_ID_CLAIM = "memberId";
     private static final String BEARER = "Bearer ";
     private final MemberRepository memberRepository;
     @Value("${jwt.secret-key}")
@@ -43,23 +44,26 @@ public class JwtService {
      * AccessToken 생성 메소드
      */
     public String createAccessToken(
-            final String email
+            final String memberId
     ) {
         Date now = new Date();
         return JWT.create() // JWT 토큰을 생성하는 빌더 반환
                 .withSubject(ACCESS_TOKEN_SUBJECT) // JWT의 Subject 지정 -> AccessToken이므로 AccessToken
                 .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod)) // 토큰 만료 시간 설정
 
-                //클레임으로는 저희는 email 하나만 사용합니다.
-                //추가적으로 식별자나, 이름 등의 정보를 더 추가하셔도 됩니다.
-                //추가하실 경우 .withClaim(클래임 이름, 클래임 값) 으로 설정해주시면 됩니다
-                .withClaim(EMAIL_CLAIM, email)
-                .sign(Algorithm.HMAC512(secretKey)); // HMAC512 알고리즘 사용, application-jwt.yml에서 지정한 secret 키로 암호화
+                // 클레임으로는 memberId 하나만 사용
+                // 추가적으로 식별자나, 이름 등의 정보를 더 추가 가능
+                // .withClaim(클래임 이름, 클래임 값)로 추가
+                .withClaim(MEMBER_ID_CLAIM, memberId)
+
+                // HMAC512 알고리즘 사용
+                // application.yml에서 지정한 secretKey로 암호화
+                .sign(Algorithm.HMAC512(secretKey));
     }
 
     /**
      * RefreshToken 생성
-     * RefreshToken은 Claim에 email도 넣지 않으므로 withClaim() X
+     * RefreshToken은 Claim에 회원 정보 넣지 않으므로 withClaim() X
      */
     public String createRefreshToken(
     ) {
@@ -97,21 +101,8 @@ public class JwtService {
     }
 
     /**
-     * 헤더에서 RefreshToken 추출
-     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
-     * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
-     */
-    public Optional<String> extractRefreshToken(
-            final HttpServletRequest request
-    ) {
-        return Optional.ofNullable(request.getHeader(refreshHeader))
-                .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
-    }
-
-    /**
      * 헤더에서 AccessToken 추출
-     * 토큰 형식 : Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 토큰 형식: Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
      * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
      */
     public Optional<String> extractAccessToken(
@@ -123,13 +114,26 @@ public class JwtService {
     }
 
     /**
-     * AccessToken에서 Email 추출
+     * 헤더에서 RefreshToken 추출
+     * 토큰 형식: Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서
+     * 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
+     */
+    public Optional<String> extractRefreshToken(
+            final HttpServletRequest request
+    ) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * AccessToken에서 회원 ID 추출
      * 추출 전에 JWT.require()로 검증기 생성
      * verify로 AceessToken 검증 후
-     * 유효하다면 getClaim()으로 이메일 추출
+     * 유효하다면 getClaim()으로 회원 ID 추출
      * 유효하지 않다면 빈 Optional 객체 반환
      */
-    public Optional<String> extractEmail(
+    public Optional<UUID> extractMemberId(
             final String accessToken
     ) {
         try {
@@ -137,8 +141,8 @@ public class JwtService {
             return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
                     .build() // 반환된 빌더로 JWT verifier 생성
                     .verify(accessToken) // accessToken을 검증하고 유효하지 않다면 예외 발생
-                    .getClaim(EMAIL_CLAIM) // claim(Emial) 가져오기
-                    .asString());
+                    .getClaim(MEMBER_ID_CLAIM) // claim(MemberId) 가져오기
+                    .as(UUID.class));
         } catch (Exception e) {
             log.error("액세스 토큰이 유효하지 않습니다.");
             return Optional.empty();
@@ -169,10 +173,10 @@ public class JwtService {
      * RefreshToken DB 저장(업데이트)
      */
     public void updateRefreshToken(
-            final String email,
+            final UUID memberId,
             final String refreshToken
     ) {
-        memberRepository.findByEmail(email)
+        memberRepository.findByMemberId(memberId)
                 .ifPresentOrElse(
                         member -> member.updateRefreshToken(refreshToken),
                         () -> new Exception("일치하는 회원이 없습니다.")

--- a/src/main/java/com/coverflow/global/jwt/service/JwtService.java
+++ b/src/main/java/com/coverflow/global/jwt/service/JwtService.java
@@ -2,6 +2,7 @@ package com.coverflow.global.jwt.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.coverflow.member.domain.Member;
 import com.coverflow.member.domain.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.Optional;
@@ -172,15 +174,15 @@ public class JwtService {
     /**
      * RefreshToken DB 저장(업데이트)
      */
+    @Transactional
     public void updateRefreshToken(
             final UUID memberId,
             final String refreshToken
     ) {
-        memberRepository.findByMemberId(memberId)
-                .ifPresentOrElse(
-                        member -> member.updateRefreshToken(refreshToken),
-                        () -> new Exception("일치하는 회원이 없습니다.")
-                );
+        final Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("일치하는 회원이 없습니다."));
+        
+        member.updateRefreshToken(refreshToken);
     }
 
     public boolean isTokenValid(

--- a/src/main/java/com/coverflow/global/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/coverflow/global/oauth2/CustomOAuth2User.java
@@ -7,11 +7,12 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
 
-    private final String email;
+    private final UUID memberId;
     private final Role role;
 
     /**
@@ -26,11 +27,11 @@ public class CustomOAuth2User extends DefaultOAuth2User {
             final Collection<? extends GrantedAuthority> authorities,
             final Map<String, Object> attributes,
             final String nameAttributeKey,
-            final String email,
+            final UUID memberId,
             final Role role
     ) {
         super(authorities, attributes, nameAttributeKey);
-        this.email = email;
+        this.memberId = memberId;
         this.role = role;
     }
 }

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -47,7 +47,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             final HttpServletResponse response,
             final CustomOAuth2User oAuth2User
     ) {
-        String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+        String accessToken = jwtService.createAccessToken(String.valueOf(oAuth2User.getMemberId()));
         String refreshToken = jwtService.createRefreshToken();
         response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
         response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
@@ -55,6 +55,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         System.out.println("refreshToken = " + refreshToken);
 
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
-        jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
+        jwtService.updateRefreshToken(oAuth2User.getMemberId(), refreshToken);
     }
 }

--- a/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/coverflow/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -2,6 +2,8 @@ package com.coverflow.global.oauth2.handler;
 
 import com.coverflow.global.jwt.service.JwtService;
 import com.coverflow.global.oauth2.CustomOAuth2User;
+import com.coverflow.member.domain.Member;
+import com.coverflow.member.domain.MemberRepository;
 import com.coverflow.member.domain.Role;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 
@@ -18,41 +21,44 @@ import java.io.IOException;
 @Component
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final JwtService jwtService;
+    private final MemberRepository memberRepository;
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(
             final HttpServletRequest request,
             final HttpServletResponse response,
             final Authentication authentication
     ) throws IOException {
         log.info("OAuth2 Login 성공!");
-        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        final CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
-        loginSuccess(response, oAuth2User);
+        loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
 
         // User의 Role이 GUEST일 경우 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
         if (oAuth2User.getRole() == Role.GUEST) {
-//            String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
-//            response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
-            response.sendRedirect("/login/userinfo"); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트
-//            jwtService.sendAccessAndRefreshToken(response, accessToken, null);
+            final Member member = memberRepository.findByMemberId(oAuth2User.getMemberId())
+                    .orElseThrow(() -> new IllegalArgumentException("일치하는 회원이 없습니다."));
+
+            member.authorizeMember();
+
+            response.sendRedirect("/login/member-info"); // 프론트의 추가 정보 입력 폼으로 리다이렉트
         }
-//        else {
-//            loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
-//        }
     }
 
-    // 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
+    // 소셜 로그인 후
+    // 리프레쉬 토큰 유무에 관계없이(첫 사용자, 기존 사용자 모두)
+    // 액세스 + 리프레쉬 토큰 발급
+    // 즉, 리프레쉬 토큰은 1회용(보안 강화)
     private void loginSuccess(
             final HttpServletResponse response,
             final CustomOAuth2User oAuth2User
     ) {
-        String accessToken = jwtService.createAccessToken(String.valueOf(oAuth2User.getMemberId()));
-        String refreshToken = jwtService.createRefreshToken();
+        final String accessToken = jwtService.createAccessToken(String.valueOf(oAuth2User.getMemberId()));
+        final String refreshToken = jwtService.createRefreshToken();
+
         response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
         response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
-        System.out.println("accessToken = " + accessToken);
-        System.out.println("refreshToken = " + refreshToken);
 
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
         jwtService.updateRefreshToken(oAuth2User.getMemberId(), refreshToken);

--- a/src/main/java/com/coverflow/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/coverflow/global/oauth2/service/CustomOAuth2UserService.java
@@ -63,7 +63,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().getKey())),
                 attributes,
                 extractAttributes.getNameAttributeKey(),
-                createdMember.getEmail(),
+                createdMember.getMemberId(),
                 createdMember.getRole()
         );
     }

--- a/src/main/java/com/coverflow/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/coverflow/global/oauth2/service/CustomOAuth2UserService.java
@@ -39,24 +39,24 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
          * 사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환한다.
          * 결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저
          */
-        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
-        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        final OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
         /**
          * userRequest에서 registrationId 추출 후 registrationId으로 SocialType 저장
          * http://localhost:8080/oauth2/authorization/kakao에서 kakao가 registrationId
          * userNameAttributeName은 이후에 nameAttributeKey로 설정된다.
          */
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        SocialType socialType = getSocialType(registrationId);
-        String userNameAttributeName = userRequest.getClientRegistration()
+        final String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        final SocialType socialType = getSocialType(registrationId);
+        final String userNameAttributeName = userRequest.getClientRegistration()
                 .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName(); // OAuth2 로그인 시 키(PK)가 되는 값
-        Map<String, Object> attributes = oAuth2User.getAttributes(); // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
+        final Map<String, Object> attributes = oAuth2User.getAttributes(); // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
 
         // socialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
-        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+        final OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
 
-        Member createdMember = getMember(extractAttributes, socialType); // getMember() 메소드로 Member 객체 생성 후 반환
+        final Member createdMember = getMember(extractAttributes, socialType); // getMember() 메소드로 Member 객체 생성 후 반환
 
         // DefaultOAuth2User를 구현한 CustomOAuth2User 객체를 생성해서 반환
         return new CustomOAuth2User(
@@ -88,8 +88,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             final OAuthAttributes attributes,
             final SocialType socialType
     ) {
-        Member findMember = memberRepository.findBySocialTypeAndSocialId(socialType,
-                attributes.getOauth2UserInfo().getId()).orElse(null);
+        final Member findMember = memberRepository.findBySocialTypeAndSocialId(
+                        socialType,
+                        attributes.getOauth2UserInfo().getId()
+                )
+                .orElse(null);
 
         if (findMember == null) {
             return saveMember(attributes, socialType);
@@ -105,7 +108,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             final OAuthAttributes attributes,
             final SocialType socialType
     ) {
-        Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+        final Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
         return memberRepository.save(createdMember);
     }
 }

--- a/src/main/java/com/coverflow/member/application/MemberService.java
+++ b/src/main/java/com/coverflow/member/application/MemberService.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Log4j2
@@ -22,7 +23,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-//    public void signUp(final MemberSignUpDTO memberSignUpDTO) throws Exception {
+    //    public void signUp(final MemberSignUpDTO memberSignUpDTO) throws Exception {
 //        if (memberRepository.findByEmail(memberSignUpDTO.getEmail()).isPresent()) {
 //            throw new Exception("이미 존재하는 이메일입니다.");
 //        }
@@ -42,6 +43,14 @@ public class MemberService {
 //        member.passwordEncode(passwordEncoder);
 //        memberRepository.save(member);
 //    }
+    public void AuthorizeMember(
+            final UUID memberId
+    ) {
+        final Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("일치하는 회원이 없습니다."));
+        
+        member.authorizeMember();
+    }
 
     @Transactional(readOnly = true)
     public MemberVerifyDuplicationNicknameResponse verifyDuplicationNickname(
@@ -66,7 +75,7 @@ public class MemberService {
             final String username,
             final MemberSaveMemberInfoRequest request
     ) {
-        final Member member = memberRepository.findByEmail(username)
+        final Member member = memberRepository.findByMemberId(UUID.fromString(username))
                 .orElseThrow(() -> new IllegalArgumentException("일치하는 회원이 없습니다."));
 
         member.saveMemberInfo(request);

--- a/src/main/java/com/coverflow/member/domain/Member.java
+++ b/src/main/java/com/coverflow/member/domain/Member.java
@@ -58,6 +58,12 @@ public class Member extends BaseEntity {
         this.gender = request.gender();
     }
 
+    public void updateRefreshToken(
+            final String updateRefreshToken
+    ) {
+        this.refreshToken = updateRefreshToken;
+    }
+
     public void updateNickname(
             final String updateNickname
     ) {
@@ -75,11 +81,5 @@ public class Member extends BaseEntity {
             final PasswordEncoder passwordEncoder
     ) {
         this.password = passwordEncoder.encode(updatePassword);
-    }
-
-    public void updateRefreshToken(
-            final String updateRefreshToken
-    ) {
-        this.refreshToken = updateRefreshToken;
     }
 }

--- a/src/main/java/com/coverflow/member/domain/Member.java
+++ b/src/main/java/com/coverflow/member/domain/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID member_id;
+    private UUID memberId;
     private String password;
     private String email;
     private String nickname;

--- a/src/main/java/com/coverflow/member/domain/MemberRepository.java
+++ b/src/main/java/com/coverflow/member/domain/MemberRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface MemberRepository extends JpaRepository<Member, UUID> {
+    Optional<Member> findByMemberId(UUID memberId);
 
     Optional<Member> findByEmail(final String email);
 


### PR DESCRIPTION
# ✨(#이슈 번호)
- closed #30 

# ✏️내용
1. 로그인 시 회원 이중 조회 버그
- 카카오 로그인 -> 뒤로가서 카카오로 다시 로그인 -> n번해도 잘 됨
- 카카오 로그인 -> 뒤로가서 네이버로 다시 로그인 -> IncorrectResultSizeDataAccessException: query did not return a unique result: 2 오류남

즉, 로그인 시 DB에서 회원 조회할 때 찾는 회원 데이터가 2개 이상이라 오류가 났습니다.
원인은 회원 조회 시 회원의 이메일로 조회하는데 
제 카카오랑 네이버 아이디가 같은 이메일이여서 
DB에도 실제로 이메일이 중복으로 들어갔어요.
스프링 입장에선 찾는 이메일이 두 개라 오류가 났던겁니다.
그래서 회원 조회를 이메일로 하는 방식에서 회원의 고유 아이디 값으로 조회하도록 수정했습니다.

- 버그 모습
![2](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/8fbd903b-a88e-4760-aa9c-cb9e670e937b)

- 이메일말구 회원 아이디로 찾도록 로직 변경
![3](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/21f66f8b-957a-4b52-b6aa-a4d582031817)
![4](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/202fee7b-fa38-4b20-8103-8b9da9d96643)
![5](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/d0484df0-7729-4a61-8fd2-0a4e4b4ab2ce)
![6](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/ae7a4491-7300-4883-b4af-388c51bb6b4e)
![7](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/48d04882-2e09-4420-b8b7-a4d4aacbb325)
![8](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/a9a3c7d2-b5ca-48ae-a85f-d3a25f7f732b)

---
2. 리프레쉬 토큰 저장 이슈
리프레쉬 토큰과 회원의 권한이 계속 GUEST에서 안 바뀌는 이슈가 있었습니다.
DB에 update 시 Entity에서 정적 팩토리 메서드 만들어서 해주고 있었습니다.
그런데 계속 저장이 안 되길래 원인이 뭔가 했더니
@Transactional 어노테이션이 없어서 그랬습니다.

JPA는 엔티티를 조회하면 현재 상태를 스냅샷으로 만들어 영속성 컨텍스트에 보관하고 있습니다. 
트랜잭션이 commit됐을 시점에 Dirty Checking 을 한 다음에 DB에 엔티티를 자동으로 반영해줍니다.
(트랜잭션이란 한 문장으로 정의해 보면 데이터베이스의 상태를 변화시키기 위해서 수행하는 작업의 단위를 의미합니다. )

하지만 저는 update함수(리프레쉬 토큰 등록, 권한 등록)를 통해 엔티티에 변화만 줬을 뿐이지 
JPA의 save함수를 사용해 트랜잭션을 커밋해주지 않았습니다.
(리프레쉬 토큰이랑 권한 MEMBER로 바꿀거야 << 시점에서 행동을 안 해서 마무리가 안 됐다는 말입니다.)

@Transactional 어노테이션은 이 트랜잭션을 커밋할 수 있습니다.
따라서 리프레쉬 토큰이랑 권한 변경 과정을 커밋시켜줘서 해결했습니다.

- @Transactional 어노테이션 붙인 모습
![9](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/e01824b2-f2c0-45a4-95b9-f927102fd3e3)
![11](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/c3705ffb-6c59-4790-a5e7-7b10677d92e4)

- 결과
![10](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/f2c9a7ab-48d4-4759-b50d-f2774b2600d7)
