### PR TITLE
[BugFix] - 회사,질문,답변 조회 로직 수정했습니다.

### DIFF
--- a/src/main/java/com/coverflow/company/dto/response/FindCompanyResponse.java
+++ b/src/main/java/com/coverflow/company/dto/response/FindCompanyResponse.java
@@ -4,7 +4,6 @@ import com.coverflow.company.domain.Company;
 import com.coverflow.question.dto.QuestionDTO;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record FindCompanyResponse(
         Long companyId,
@@ -16,7 +15,9 @@ public record FindCompanyResponse(
         List<QuestionDTO> questions
 ) {
 
-    public static FindCompanyResponse from(final Company company) {
+    public static FindCompanyResponse of(
+            final Company company,
+            final List<QuestionDTO> questions) {
         return new FindCompanyResponse(
                 company.getId(),
                 company.getName(),
@@ -24,18 +25,7 @@ public record FindCompanyResponse(
                 company.getCity() + " " + company.getDistrict(),
                 company.getEstablishment(),
                 company.getQuestionCount(),
-                company.getQuestions().stream()
-                        .map(question -> new QuestionDTO(
-                                question.getMember().getNickname(),
-                                question.getMember().getTag(),
-                                question.getTitle(),
-                                question.getContent(),
-                                question.getViewCount(),
-                                question.getAnswerCount(),
-                                question.getReward(),
-                                question.getCreatedAt()
-                        ))
-                        .collect(Collectors.toList())
+                questions
         );
     }
 }

--- a/src/main/java/com/coverflow/company/infrastructure/CompanyRepository.java
+++ b/src/main/java/com/coverflow/company/infrastructure/CompanyRepository.java
@@ -1,6 +1,7 @@
 package com.coverflow.company.infrastructure;
 
 import com.coverflow.company.domain.Company;
+import com.coverflow.question.domain.Question;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -34,12 +35,18 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
 
     Optional<Company> findByName(final String name);
 
-    @Query("SELECT distinct c " +
+    @Query("SELECT DISTINCT c " +
             "FROM Company c " +
-            "LEFT JOIN FETCH c.questions q " +
             "WHERE c.id = :companyId " +
-            "AND c.status = '등록' ")
-    Optional<Company> findByCompanyIdWithQuestion(@Param("companyId") final Long companyId);
+            "AND c.status = '등록'")
+    Optional<Company> findRegisteredCompany(@Param("companyId") final Long companyId);
+
+    @Query("SELECT q " +
+            "FROM Question q " +
+            "WHERE q.company.id = :companyId " +
+            "AND q.status = '등록' " +
+            "ORDER BY q.createdAt DESC")
+    Optional<List<Question>> findRegisteredQuestions(@Param("companyId") final Long companyId);
 
     Optional<List<Company>> findByStatus(final String status);
 }

--- a/src/main/java/com/coverflow/question/dto/AnswerDTO.java
+++ b/src/main/java/com/coverflow/question/dto/AnswerDTO.java
@@ -1,0 +1,21 @@
+package com.coverflow.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerDTO {
+
+    private Long id;
+    private String nickname;
+    private String tag;
+    private String content;
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/coverflow/question/dto/response/FindQuestionResponse.java
+++ b/src/main/java/com/coverflow/question/dto/response/FindQuestionResponse.java
@@ -1,10 +1,10 @@
 package com.coverflow.question.dto.response;
 
 import com.coverflow.question.domain.Question;
+import com.coverflow.question.dto.AnswerDTO;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record FindQuestionResponse(
         Long questionId,
@@ -16,10 +16,12 @@ public record FindQuestionResponse(
         String questionNickname,
         String questionTag,
         LocalDateTime createAt,
-        List<FindAnswerResponse> answers
+        List<AnswerDTO> answers
 ) {
 
-    public static FindQuestionResponse from(final Question question) {
+    public static FindQuestionResponse of(
+            final Question question,
+            final List<AnswerDTO> answers) {
         return new FindQuestionResponse(
                 question.getId(),
                 question.getTitle(),
@@ -30,15 +32,7 @@ public record FindQuestionResponse(
                 question.getMember().getNickname(),
                 question.getMember().getTag(),
                 question.getCreatedAt(),
-                question.getAnswers().stream()
-                        .map(answer -> new FindAnswerResponse(
-                                answer.getId(),
-                                answer.getContent(),
-                                answer.getMember().getNickname(),
-                                answer.getMember().getTag(),
-                                answer.getCreatedAt()
-                        ))
-                        .collect(Collectors.toList())
+                answers
         );
     }
 }

--- a/src/main/java/com/coverflow/question/infrastructure/QuestionRepository.java
+++ b/src/main/java/com/coverflow/question/infrastructure/QuestionRepository.java
@@ -1,5 +1,6 @@
 package com.coverflow.question.infrastructure;
 
+import com.coverflow.question.domain.Answer;
 import com.coverflow.question.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,11 +21,16 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             "ORDER BY q.createdAt DESC")
     Optional<List<Question>> findAllQuestions();
 
-    @Query("SELECT q " +
+    @Query("SELECT DISTINCT q " +
             "FROM Question q " +
-            "JOIN FETCH q.answers a " +
             "WHERE q.id = :questionId " +
+            "AND q.status = '등록'")
+    Optional<Question> findRegisteredQuestion(@Param("questionId") final Long questionId);
+
+    @Query("SELECT a " +
+            "FROM Answer a " +
+            "WHERE a.question.id = :questionId " +
             "AND a.status = '등록' " +
             "ORDER BY a.createdAt DESC")
-    Optional<Question> findByIdWithAnswers(@Param("questionId") final Long questionId);
+    Optional<List<Answer>> findRegisteredAnswers(@Param("questionId") final Long questionId);
 }


### PR DESCRIPTION
# ✨(#이슈 번호)
- closed #100 

# ✏️내용
1. 특정 회사와 질문 조회 로직 수정했습니다.
2. 특정 질문과 답변 조회 로직 수정했습니다.

1,2번 모두
1:N 관계에서 N 위치의 엔티티에 데이터가 없을 경우를 대비해
기존에 쿼리문 한 개로 한꺼번에 조회하던 것을
두 개로 분리해서 엔티티를 각각 조회합니다.