### PR TITLE
[Feature] - [Notification] 실시간 알림 기능 SSE 방식으로 구현했습니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
-    implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter'
+    implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter'
 
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/coverflow/global/config/WebConfig.java
+++ b/src/main/java/com/coverflow/global/config/WebConfig.java
@@ -11,8 +11,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         // 모든 uri에 대해 특정 도메인은 접근을 허용한다.
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:3001","http://15.165.1.48","http://15.165.1.48:3001","http://172.17.0.3:3001")
-                .allowedMethods("GET", "POST")
+                .allowedOrigins("http://localhost:3000", "http://localhost:3001", "http://15.165.1.48", "http://15.165.1.48:3001", "http://172.17.0.3:3001")
+                .allowedMethods("GET", "POST", "OPTIONS")
                 .allowCredentials(true);
     }
 }

--- a/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final HttpServletResponse response,
             final FilterChain filterChain
     ) throws ServletException, IOException {
-        System.out.println("요청 url: " + request.getRequestURI());
+        log.info("요청 URL: {}", request.getRequestURI());
         if (request.getRequestURI().equals(NO_CHECK_URL)) {
             filterChain.doFilter(request, response); // "/login" 요청이 들어오면, 다음 필터 호출
             return; // return으로 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행시킴)
@@ -133,10 +133,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         jwtService.extractAccessToken(request)
                 .filter(jwtService::isTokenValid)
                 .ifPresent(accessToken -> {
-                    System.out.println(accessToken);
                     jwtService.extractMemberId(accessToken)
                             .ifPresent(memberId -> {
-                                System.out.println(memberId);
                                 memberRepository.findByIdAndStatus(memberId, "등록")
                                         .ifPresent(this::saveAuthentication);
                             });

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,14 +1,17 @@
 package com.coverflow.global.oauth2.userinfo;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Map;
 
+@Slf4j
 public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
 
     public GoogleOAuth2UserInfo(
             final Map<String, Object> attributes
     ) {
         super(attributes);
-        System.out.println("attributes = " + attributes);
+        log.info("attributes: {}", attributes);
     }
 
     @Override

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,14 +1,17 @@
 package com.coverflow.global.oauth2.userinfo;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Map;
 
+@Slf4j
 public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
     public KakaoOAuth2UserInfo(
             final Map<String, Object> attributes
     ) {
         super(attributes);
-        System.out.println("attributes = " + attributes);
+        log.info("attributes: {}", attributes);
     }
 
     @Override

--- a/src/main/java/com/coverflow/global/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/coverflow/global/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -1,14 +1,17 @@
 package com.coverflow.global.oauth2.userinfo;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Map;
 
+@Slf4j
 public class NaverOAuth2UserInfo extends OAuth2UserInfo {
 
     public NaverOAuth2UserInfo(
             final Map<String, Object> attributes
     ) {
         super(attributes);
-        System.out.println("attributes = " + attributes);
+        log.info("attributes: {}", attributes);
     }
 
     @Override

--- a/src/main/java/com/coverflow/global/util/NicknameUtil.java
+++ b/src/main/java/com/coverflow/global/util/NicknameUtil.java
@@ -51,13 +51,11 @@ public class NicknameUtil {
             Collections.shuffle(secondName);
 
             nickname = firstName.get(0) + " " + secondName.get(0);
-            System.out.println("Generated nickname = " + nickname);
 
             member = memberRepository.findByNickname(nickname);
 
         } while (member.isPresent()); // 해당 닉네임을 가진 회원이 존재하면 계속 반복
-
-        System.out.println("Final nickname = " + nickname);
+        
         return nickname; // 유일한 닉네임 반환
     }
 }

--- a/src/main/java/com/coverflow/member/application/MemberService.java
+++ b/src/main/java/com/coverflow/member/application/MemberService.java
@@ -8,6 +8,7 @@ import com.coverflow.member.dto.response.FindMemberInfoResponse;
 import com.coverflow.member.dto.response.UpdateNicknameResponse;
 import com.coverflow.member.exception.MemberException;
 import com.coverflow.member.infrastructure.MemberRepository;
+import com.coverflow.notification.infrastructure.EmitterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,13 +23,14 @@ import java.util.UUID;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    //    private final PasswordEncoder passwordEncoder;
+    private final EmitterRepository emitterRepository;
     private final NicknameUtil nicknameUtil;
-
-    /**
-     * 폼 로그인 구현 시 사용할 예정
-     */
-    //    public void signUp(final MemberSignUpDTO memberSignUpDTO) throws Exception {
+//    private final PasswordEncoder passwordEncoder;
+//
+//    /**
+//     * 폼 로그인 구현 시 사용할 예정
+//     */
+//    public void signUp(final MemberSignUpDTO memberSignUpDTO) throws Exception {
 //        if (memberRepository.findByEmail(memberSignUpDTO.getEmail()).isPresent()) {
 //            throw new Exception("이미 존재하는 이메일입니다.");
 //        }
@@ -110,6 +112,8 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(username));
 
         member.updateTokenStatus("로그아웃");
+        emitterRepository.deleteAllStartWithId(username);
+        emitterRepository.deleteAllEventCacheStartWithId(username);
     }
 
     /**
@@ -123,6 +127,8 @@ public class MemberService {
         member.updateTokenStatus("로그아웃");
         member.updateAuthorization(Role.GUEST);
         member.updateStatus("탈퇴");
+        emitterRepository.deleteAllStartWithId(username);
+        emitterRepository.deleteAllEventCacheStartWithId(username);
     }
 }
 

--- a/src/main/java/com/coverflow/member/application/MemberService.java
+++ b/src/main/java/com/coverflow/member/application/MemberService.java
@@ -97,6 +97,7 @@ public class MemberService {
         final String nickname = nicknameUtil.generateRandomNickname();
 
         member.updateNickname(nickname);
+        member.updateFishShapedBun(member.getFishShapedBun() - 50);
         return UpdateNicknameResponse.from(nickname);
     }
 

--- a/src/main/java/com/coverflow/notification/application/NotificationService.java
+++ b/src/main/java/com/coverflow/notification/application/NotificationService.java
@@ -6,21 +6,59 @@ import com.coverflow.notification.dto.response.FindNotificationResponse;
 import com.coverflow.notification.exception.NotificationException;
 import com.coverflow.notification.infrastructure.NotificationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    /**
+     * [보낼 메시지 담는 메서드]
+     */
+    public SseEmitter add(SseEmitter emitter) {
+        emitters.add(emitter);
+        log.info("new emitter added: {}", emitter);
+        log.info("emitter list size: {}", emitters.size());
+        log.info("emitter list: {}", emitters);
+        emitter.onCompletion(() -> {
+            log.info("onCompletion callback");
+            emitters.remove(emitter);
+        });
+        emitter.onTimeout(() -> {
+            log.info("onTimeout callback");
+            emitter.complete();
+        });
+
+        return emitter;
+    }
+
+    public void alert() {
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("alert")
+                        .data("count"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
 
     /**
      * [알림 조회 메서드]
@@ -58,4 +96,5 @@ public class NotificationService {
         LocalDateTime date = LocalDateTime.now().minusDays(30);
         notificationRepository.deleteByCreatedAt(date);
     }
+
 }

--- a/src/main/java/com/coverflow/notification/application/NotificationService.java
+++ b/src/main/java/com/coverflow/notification/application/NotificationService.java
@@ -120,7 +120,9 @@ public class NotificationService {
         final List<FindNotificationResponse> findNotifications = new ArrayList<>();
 
         for (int i = 0; i < notifications.size(); i++) {
-            findNotifications.add(i, FindNotificationResponse.from(notifications.get(i)));
+            if (notifications.get(i).getCreatedAt().isAfter(LocalDateTime.now().minusDays(31))) {
+                findNotifications.add(i, FindNotificationResponse.from(notifications.get(i)));
+            }
         }
         return findNotifications;
     }

--- a/src/main/java/com/coverflow/notification/application/NotificationService.java
+++ b/src/main/java/com/coverflow/notification/application/NotificationService.java
@@ -4,6 +4,7 @@ import com.coverflow.notification.domain.Notification;
 import com.coverflow.notification.dto.request.UpdateNotificationRequest;
 import com.coverflow.notification.dto.response.FindNotificationResponse;
 import com.coverflow.notification.exception.NotificationException;
+import com.coverflow.notification.infrastructure.EmitterRepository;
 import com.coverflow.notification.infrastructure.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +17,8 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Slf4j
 @Transactional(readOnly = true)
@@ -25,39 +26,89 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @Service
 public class NotificationService {
 
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    private final EmitterRepository emitterRepository;
     private final NotificationRepository notificationRepository;
-    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
     /**
-     * [보낼 메시지 담는 메서드]
+     * [알림 서버 연결 메서드]
+     * 알림 서버 접속 시 요청 회원의 고유 이벤트 id를 key, SseEmitter 인스턴스를 value로
+     * 알림 서버 저장소에 추가합니다.
      */
-    public SseEmitter add(SseEmitter emitter) {
-        emitters.add(emitter);
-        log.info("new emitter added: {}", emitter);
-        log.info("emitter list size: {}", emitters.size());
-        log.info("emitter list: {}", emitters);
+    public SseEmitter connect(
+            final String memberId,
+            final String lastEventId
+    ) {
+        // 매 연결마다 고유 이벤트 id 부여
+        final String eventId = memberId + "_" + System.currentTimeMillis();
+
+        // SseEmitter 인스턴스 생성 후 Map에 저장
+        final SseEmitter emitter = emitterRepository.save(eventId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        // 이벤트 전송 시
         emitter.onCompletion(() -> {
             log.info("onCompletion callback");
-            emitters.remove(emitter);
+            emitterRepository.delete(eventId);
         });
+
+        // 이벤트 스트림 연결 끊길 시
         emitter.onTimeout(() -> {
             log.info("onTimeout callback");
             emitter.complete();
+            emitterRepository.delete(eventId);
         });
+
+        // 첫 연결 시 503 Service Unavailable 방지용 더미 Event 전송
+        sendToClient(eventId, emitter, "알림 서버 연결 성공. [memberId = " + memberId + "]");
+
+        // 클라이언트가 미수신한 Event 목록이 존재할 경우 모두 전송
+        if (!lastEventId.isEmpty()) {
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(memberId);
+            events.entrySet().stream()
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .forEach(entry -> sendToClient(entry.getKey(), emitter, entry.getValue()));
+        }
 
         return emitter;
     }
 
-    public void alert() {
-        emitters.forEach(emitter -> {
-            try {
-                emitter.send(SseEmitter.event()
-                        .name("alert")
-                        .data("count"));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
+    /**
+     * [알림 전송 메서드]
+     */
+    @Transactional
+    public void sendNotification(final Notification notification) {
+        notificationRepository.save(notification);
+
+        // 로그인 한 유저의 SseEmitter 모두 가져오기
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEventStartWithId(String.valueOf(notification.getMember().getId()));
+        sseEmitters.forEach(
+                (key, emitter) -> {
+                    // 데이터 캐시 저장(유실된 데이터 처리하기 위함)
+                    emitterRepository.saveEventCache(key, notification);
+                    // 데이터 전송
+                    sendToClient(key, emitter, notification);
+                }
+        );
+    }
+
+    /**
+     * [직접 이벤트를 클라이언트로 전송하는 메서드]
+     */
+    private void sendToClient(
+            final String eventId,
+            final SseEmitter emitter,
+            final Object object
+    ) {
+        try {
+            emitter.send(SseEmitter
+                    .event()
+                    .id(eventId)
+                    .name("connect")
+                    .data(object)
+            );
+        } catch (IOException e) {
+            throw new RuntimeException("알림 서버 연결 오류");
+        }
     }
 
     /**

--- a/src/main/java/com/coverflow/notification/domain/Notification.java
+++ b/src/main/java/com/coverflow/notification/domain/Notification.java
@@ -17,7 +17,9 @@ public class Notification extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 알림 고유 번호
     @Column
-    private String content; // 내용 (질문 고유 번호, 답변 고유 번호 등)
+    private String content; // 내용
+    @Column
+    private String url; // 필요 시 리다이렉트 시킬 url
     @Column
     private String status; // 상태 (안읽음/읽음/삭제)
 

--- a/src/main/java/com/coverflow/notification/dto/response/FindNotificationResponse.java
+++ b/src/main/java/com/coverflow/notification/dto/response/FindNotificationResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 public record FindNotificationResponse(
         String content,
+        String url,
         NotificationType type,
         String status,
         LocalDateTime createdAt
@@ -15,6 +16,7 @@ public record FindNotificationResponse(
     public static FindNotificationResponse from(Notification notification) {
         return new FindNotificationResponse(
                 notification.getContent(),
+                notification.getUrl(),
                 notification.getType(),
                 notification.getStatus(),
                 notification.getCreatedAt()

--- a/src/main/java/com/coverflow/notification/infrastructure/EmitterRepository.java
+++ b/src/main/java/com/coverflow/notification/infrastructure/EmitterRepository.java
@@ -1,0 +1,76 @@
+package com.coverflow.notification.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Repository
+public class EmitterRepository {
+
+    private final Map<String, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    public SseEmitter save(
+            final String eventId,
+            final SseEmitter sseEmitter
+    ) {
+        emitterMap.remove(eventId);
+        emitterMap.put(eventId, sseEmitter);
+
+        log.info("[SseEmitter] Set {}", eventId);
+        return sseEmitter;
+    }
+
+    public void saveEventCache(String id, Object event) {
+        eventCache.put(id, event);
+    }
+
+    public Optional<SseEmitter> get(final String memberId) {
+        SseEmitter sseEmitter = emitterMap.get(memberId);
+
+        log.info("[SseEmitter] Get {}", memberId);
+        return Optional.ofNullable(sseEmitter);
+    }
+
+    public Map<String, SseEmitter> findAllEventStartWithId(final String memberId) {
+        return emitterMap.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String, Object> findAllEventCacheStartWithId(final String memberId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void delete(final String eventId) {
+        emitterMap.remove(eventId);
+    }
+
+    public void deleteAllStartWithId(final String memberId) {
+        emitterMap.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        emitterMap.remove(key);
+                    }
+                }
+        );
+    }
+
+    public void deleteAllEventCacheStartWithId(final String memberId) {
+        eventCache.forEach(
+                (key, data) -> {
+                    if (key.startsWith(memberId)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/coverflow/notification/presentation/NotificationController.java
+++ b/src/main/java/com/coverflow/notification/presentation/NotificationController.java
@@ -2,47 +2,75 @@ package com.coverflow.notification.presentation;
 
 import com.coverflow.global.handler.ResponseHandler;
 import com.coverflow.notification.application.NotificationService;
-import com.coverflow.notification.dto.request.UpdateNotificationRequest;
-import com.coverflow.notification.dto.response.FindNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.List;
+import java.io.IOException;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/notification")
 @RestController
 public class NotificationController {
 
+    //    private final SseEmitter sseEmitters;
     private final NotificationService notificationService;
 
-    @GetMapping("/find-notification")
-    public ResponseEntity<ResponseHandler<List<FindNotificationResponse>>> findNotification(
-            @AuthenticationPrincipal final UserDetails userDetails
-    ) {
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<ResponseHandler<SseEmitter>> connect() {
+        final SseEmitter emitter = new SseEmitter();
+        
+        notificationService.add(emitter);
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("connected!"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         return ResponseEntity.ok()
-                .body(ResponseHandler.<List<FindNotificationResponse>>builder()
+                .body(ResponseHandler.<SseEmitter>builder()
                         .statusCode(HttpStatus.OK)
-                        .message("알림 조회에 성공했습니다.")
-                        .data(notificationService.findNotification(userDetails.getUsername()))
+                        .message("알림 서버 연결 성공했습니다.")
+                        .data(emitter)
                         .build()
                 );
     }
 
-    @PostMapping("/update-notification")
-    public ResponseEntity<ResponseHandler<Void>> updateNotification(
-            @RequestBody final List<UpdateNotificationRequest> requests
-    ) {
-        notificationService.updateNotification(requests);
-        return ResponseEntity.ok()
-                .body(ResponseHandler.<Void>builder()
-                        .statusCode(HttpStatus.OK)
-                        .message("알림 변경에 성공했습니다.")
-                        .build()
-                );
+    @PostMapping("/count")
+    public ResponseEntity<Void> count() {
+        return ResponseEntity.ok().build();
     }
+
+//    @GetMapping("/find-notification")
+//    public ResponseEntity<ResponseHandler<List<FindNotificationResponse>>> findNotification(
+//            @AuthenticationPrincipal final UserDetails userDetails
+//    ) {
+//        return ResponseEntity.ok()
+//                .body(ResponseHandler.<List<FindNotificationResponse>>builder()
+//                        .statusCode(HttpStatus.OK)
+//                        .message("알림 조회에 성공했습니다.")
+//                        .data(notificationService.findNotification(userDetails.getUsername()))
+//                        .build()
+//                );
+//    }
+//
+//    @PostMapping("/update-notification")
+//    public ResponseEntity<ResponseHandler<Void>> updateNotification(
+//            @RequestBody final List<UpdateNotificationRequest> requests
+//    ) {
+//        notificationService.updateNotification(requests);
+//        return ResponseEntity.ok()
+//                .body(ResponseHandler.<Void>builder()
+//                        .statusCode(HttpStatus.OK)
+//                        .message("알림 변경에 성공했습니다.")
+//                        .build()
+//                );
+//    }
 }

--- a/src/main/java/com/coverflow/notification/presentation/NotificationController.java
+++ b/src/main/java/com/coverflow/notification/presentation/NotificationController.java
@@ -1,76 +1,66 @@
 package com.coverflow.notification.presentation;
 
+import com.coverflow.global.annotation.MemberAuthorize;
 import com.coverflow.global.handler.ResponseHandler;
 import com.coverflow.notification.application.NotificationService;
+import com.coverflow.notification.dto.request.UpdateNotificationRequest;
+import com.coverflow.notification.dto.response.FindNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/notification")
 @RestController
 public class NotificationController {
 
-    //    private final SseEmitter sseEmitters;
     private final NotificationService notificationService;
 
     @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<ResponseHandler<SseEmitter>> connect() {
-        final SseEmitter emitter = new SseEmitter();
-        
-        notificationService.add(emitter);
-        try {
-            emitter.send(SseEmitter.event()
-                    .name("connect")
-                    .data("connected!"));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    @MemberAuthorize
+    public ResponseEntity<ResponseHandler<SseEmitter>> connect(
+            @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") final String lastEventId,
+            @AuthenticationPrincipal final UserDetails userDetails
+    ) {
         return ResponseEntity.ok()
                 .body(ResponseHandler.<SseEmitter>builder()
                         .statusCode(HttpStatus.OK)
                         .message("알림 서버 연결 성공했습니다.")
-                        .data(emitter)
+                        .data(notificationService.connect(userDetails.getUsername(), lastEventId))
                         .build()
                 );
     }
 
-    @PostMapping("/count")
-    public ResponseEntity<Void> count() {
-        return ResponseEntity.ok().build();
+    @GetMapping("/find-notification")
+    public ResponseEntity<ResponseHandler<List<FindNotificationResponse>>> findNotification(
+            @AuthenticationPrincipal final UserDetails userDetails
+    ) {
+        return ResponseEntity.ok()
+                .body(ResponseHandler.<List<FindNotificationResponse>>builder()
+                        .statusCode(HttpStatus.OK)
+                        .message("알림 조회에 성공했습니다.")
+                        .data(notificationService.findNotification(userDetails.getUsername()))
+                        .build()
+                );
     }
 
-//    @GetMapping("/find-notification")
-//    public ResponseEntity<ResponseHandler<List<FindNotificationResponse>>> findNotification(
-//            @AuthenticationPrincipal final UserDetails userDetails
-//    ) {
-//        return ResponseEntity.ok()
-//                .body(ResponseHandler.<List<FindNotificationResponse>>builder()
-//                        .statusCode(HttpStatus.OK)
-//                        .message("알림 조회에 성공했습니다.")
-//                        .data(notificationService.findNotification(userDetails.getUsername()))
-//                        .build()
-//                );
-//    }
-//
-//    @PostMapping("/update-notification")
-//    public ResponseEntity<ResponseHandler<Void>> updateNotification(
-//            @RequestBody final List<UpdateNotificationRequest> requests
-//    ) {
-//        notificationService.updateNotification(requests);
-//        return ResponseEntity.ok()
-//                .body(ResponseHandler.<Void>builder()
-//                        .statusCode(HttpStatus.OK)
-//                        .message("알림 변경에 성공했습니다.")
-//                        .build()
-//                );
-//    }
+    @PostMapping("/update-notification")
+    public ResponseEntity<ResponseHandler<Void>> updateNotification(
+            @RequestBody final List<UpdateNotificationRequest> requests
+    ) {
+        notificationService.updateNotification(requests);
+        return ResponseEntity.ok()
+                .body(ResponseHandler.<Void>builder()
+                        .statusCode(HttpStatus.OK)
+                        .message("알림 상태 변경에 성공했습니다.")
+                        .build()
+                );
+    }
 }

--- a/src/main/java/com/coverflow/notification/presentation/NotificationController.java
+++ b/src/main/java/com/coverflow/notification/presentation/NotificationController.java
@@ -45,7 +45,7 @@ public class NotificationController {
         return ResponseEntity.ok()
                 .body(ResponseHandler.<List<FindNotificationResponse>>builder()
                         .statusCode(HttpStatus.OK)
-                        .message("알림 조회에 성공했습니다.")
+                        .message("최근 30일 이내의 전체 알림 조회에 성공했습니다.")
                         .data(notificationService.findNotification(userDetails.getUsername()))
                         .build()
                 );

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <property name="LOG_DIR" value="./target"/>
+    <property name="LOG_PATH_NAME" value="${LOG_DIR}/http-access.log"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH_NAME}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH_NAME}.%d{yyyyMMdd}</fileNamePattern>
+            <maxHistory>1</maxHistory> <!-- 보관기간(개월) -->
+        </rollingPolicy>
         <encoder>
-            <pattern>
-                %n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n
+            <pattern>%t{yyyy-MM-dd HH:mm:ss}\t%a\t%r\t%s\t%i{Referer}\t%i{User-Agent}\t%D\t%I
+                %fullRequest%n%fullResponse
             </pattern>
         </encoder>
     </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%n###### HTTP Request ######%n%fullRequest%n###### HTTP Response
+                ######%n%fullResponse%n%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender-ref ref="FILE"/>
     <appender-ref ref="STDOUT"/>
 </configuration>

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n
+            </pattern>
+        </encoder>
+    </appender>
+    <appender-ref ref="STDOUT"/>
+</configuration>


### PR DESCRIPTION
# ✨(#이슈 번호)
- closed #102 

# ✏️내용
기존에는 클라이언트에서 주기적으로 알림 조회 API를 호출하는 방식(short polling)이었습니다.
이는 많은 리소스를 요구하게 되기 때문에 
클라이언트에서 한 번 연결만 하면 서버에서 지속적으로 알림을 줄 수 있는 SSE(Server Sent Event) 방식으로 기능을 수정하게 되었습니다.
스프링 부트에서 SSE는 비동기 방식, 멀티 쓰레드 환경이라 다수의 사용자가 알림 서비스를 이용할 수 있습니다.

1. 출석 체크 시 로그인 한 본인에게 알림이 갑니다.
2. 답변 등록 시 해당 질문의 회원에게 알림이 갑니다.
3. 답변 채택 시 해당 답변의 회원에게 알림이 갑니다.

모든 알림은 DB에 쌓입니다.