### PR TITLE
[BugFix] - 수정/삭제 메서드 전체 수정했습니다.

### DIFF
--- a/src/main/java/com/coverflow/company/application/CompanyService.java
+++ b/src/main/java/com/coverflow/company/application/CompanyService.java
@@ -128,43 +128,24 @@ public class CompanyService {
     }
 
     /**
-     * [관리자 전용: 기업 상태 변경 메서드]
-     */
-    @Transactional
-    public void updateStatus(final long companyId) {
-        Company company = companyRepository.findById(companyId)
-                .orElseThrow(() -> new CompanyException.CompanyNotFoundException(companyId));
-
-        company.updateCompanyStatus(CompanyStatus.REGISTRATION);
-    }
-
-    /**
      * [관리자 전용: 기업 수정 메서드]
      */
     @Transactional
-    public void update(final UpdateCompanyRequest request) {
-        Company company = companyRepository.findById(request.companyId())
-                .orElseThrow(() -> new CompanyException.CompanyNotFoundException(request.companyId()));
-
-        company.updateCompany(request);
-    }
-
-    /**
-     * [관리자 전용: 기업 삭제 메서드]
-     */
-    @Transactional
-    public void delete(final long companyId) {
+    public void update(
+            final long companyId,
+            final UpdateCompanyRequest request
+    ) {
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new CompanyException.CompanyNotFoundException(companyId));
 
-        company.updateCompanyStatus(CompanyStatus.DELETION);
+        company.updateCompany(request);
     }
 
     /**
      * [관리자 전용: 기업 물리 삭제 메서드]
      */
     @Transactional
-    public void deleteData(final long companyId) {
+    public void delete(final long companyId) {
         Company company = companyRepository.findById(companyId)
                 .orElseThrow(() -> new CompanyException.CompanyNotFoundException(companyId));
 

--- a/src/main/java/com/coverflow/company/domain/Company.java
+++ b/src/main/java/com/coverflow/company/domain/Company.java
@@ -61,6 +61,7 @@ public class Company extends BaseTimeEntity {
         this.city = request.city();
         this.district = request.district();
         this.establishment = request.establishment();
+        this.companyStatus = CompanyStatus.valueOf(request.companyStatus());
     }
 
     public void updateQuestionCount(final int questionCount) {

--- a/src/main/java/com/coverflow/company/dto/request/UpdateCompanyRequest.java
+++ b/src/main/java/com/coverflow/company/dto/request/UpdateCompanyRequest.java
@@ -1,11 +1,9 @@
 package com.coverflow.company.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 
 public record UpdateCompanyRequest(
-        @Positive
-        long companyId,
+
         @NotBlank
         String name,
         @NotBlank
@@ -14,6 +12,9 @@ public record UpdateCompanyRequest(
         String city,
         @NotBlank
         String district,
-        String establishment
+        @NotBlank
+        String establishment,
+        @NotBlank
+        String companyStatus
 ) {
 }

--- a/src/main/java/com/coverflow/company/presentation/CompanyController.java
+++ b/src/main/java/com/coverflow/company/presentation/CompanyController.java
@@ -97,21 +97,10 @@ public class CompanyController {
     @PatchMapping("/admin/{companyId}")
     @AdminAuthorize
     public ResponseEntity<ResponseHandler<Void>> updateStatus(
-            @PathVariable @Positive final long companyId
+            @PathVariable @Positive final long companyId,
+            @RequestBody @Valid final UpdateCompanyRequest request
     ) {
-        companyService.updateStatus(companyId);
-        return ResponseEntity.ok()
-                .body(ResponseHandler.<Void>builder()
-                        .statusCode(HttpStatus.NO_CONTENT)
-                        .build());
-    }
-
-    @PutMapping("/admin")
-    @AdminAuthorize
-    public ResponseEntity<ResponseHandler<Void>> update(
-            @RequestBody @Valid final UpdateCompanyRequest updateCompanyRequest
-    ) {
-        companyService.update(updateCompanyRequest);
+        companyService.update(companyId, request);
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.NO_CONTENT)
@@ -120,22 +109,10 @@ public class CompanyController {
 
     @DeleteMapping("/admin/{companyId}")
     @AdminAuthorize
-    public ResponseEntity<ResponseHandler<Void>> delete(
-            @PathVariable @Positive final long companyId
-    ) {
-        companyService.delete(companyId);
-        return ResponseEntity.ok()
-                .body(ResponseHandler.<Void>builder()
-                        .statusCode(HttpStatus.NO_CONTENT)
-                        .build());
-    }
-
-    @DeleteMapping("/admin/real/{companyId}")
-    @AdminAuthorize
     public ResponseEntity<ResponseHandler<Void>> deleteData(
             @PathVariable @Positive final long companyId
     ) {
-        companyService.deleteData(companyId);
+        companyService.delete(companyId);
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/coverflow/global/exception/GlobalException.java
+++ b/src/main/java/com/coverflow/global/exception/GlobalException.java
@@ -6,6 +6,20 @@ public class GlobalException extends RuntimeException {
         super(message);
     }
 
+    public static class LogoutMemberException extends GlobalException {
+
+        public LogoutMemberException() {
+            super("이미 로그아웃을 했던 회원입니다.");
+        }
+    }
+
+    public static class JWTNotFoundException extends GlobalException {
+
+        public JWTNotFoundException() {
+            super("토큰이 비어있습니다.");
+        }
+    }
+
     public static class ExistBadwordException extends GlobalException {
 
         public ExistBadwordException() {

--- a/src/main/java/com/coverflow/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/coverflow/global/handler/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import java.util.Random;
 
 import static com.coverflow.company.exception.CompanyException.CompanyExistException;
 import static com.coverflow.company.exception.CompanyException.CompanyNotFoundException;
-import static com.coverflow.global.exception.GlobalException.ExistBadwordException;
+import static com.coverflow.global.exception.GlobalException.*;
 import static com.coverflow.inquiry.exception.InquiryException.InquiryNotFoundException;
 import static com.coverflow.member.exception.MemberException.*;
 import static com.coverflow.notification.exception.NotificationException.NotificationNotFoundException;
@@ -76,7 +76,7 @@ public class GlobalExceptionHandler {
         log.warn(exception.getMessage());
 
         return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED.value())
+                .status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse("액세스 토큰이 유효하지 않습니다."));
     }
 
@@ -91,6 +91,7 @@ public class GlobalExceptionHandler {
             AnswerNotFoundException.class,
             ReportNotFoundException.class,
             DayNotFoundException.class,
+            JWTNotFoundException.class
     })
     public ResponseEntity<ErrorResponse> handleNotFoundException(final RuntimeException exception) {
         String message = exception.getMessage();
@@ -119,6 +120,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {
             SuspendedMembershipException.class,
             NotEnoughCurrencyException.class,
+            LogoutMemberException.class,
             ExistBadwordException.class
     })
     public ResponseEntity<ErrorResponse> handleCustomBadRequestException(final RuntimeException exception) {

--- a/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/coverflow/global/jwt/filter/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    //    private static final String NO_CHECK_URL = "/login"; // "/login"으로 들어오는 요청은 Filter 작동 X
+    private static final String NO_CHECK_URL = "/login"; // "/login"으로 들어오는 요청은 Filter 작동 X
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
     private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
@@ -51,10 +51,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         log.info("요청 URL: {}", request.getRequestURI() + "?" + request.getQueryString());
         log.info("요청 Method: {}", request.getMethod());
-//        if (request.getRequestURI().equals(NO_CHECK_URL)) {
-//            filterChain.doFilter(request, response); // "/login" 요청이 들어오면, 다음 필터 호출
-//            return; // return으로 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행시킴)
-//        }
+        if (request.getRequestURI().equals(NO_CHECK_URL)) {
+            filterChain.doFilter(request, response); // "/login" 요청이 들어오면, 다음 필터 호출
+            return; // return으로 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행시킴)
+        }
 
         // 사용자 요청 헤더에서 RefreshToken 추출
         // -> RefreshToken이 없거나 유효하지 않다면(DB에 저장된 RefreshToken과 다르다면) null을 반환

--- a/src/main/java/com/coverflow/inquiry/application/InquiryService.java
+++ b/src/main/java/com/coverflow/inquiry/application/InquiryService.java
@@ -21,7 +21,8 @@ import java.util.UUID;
 import static com.coverflow.global.constant.Constant.LARGE_PAGE_SIZE;
 import static com.coverflow.global.constant.Constant.NORMAL_PAGE_SIZE;
 import static com.coverflow.global.util.PageUtil.generatePageDesc;
-import static com.coverflow.inquiry.domain.InquiryStatus.*;
+import static com.coverflow.inquiry.domain.InquiryStatus.COMPLETE;
+import static com.coverflow.inquiry.domain.InquiryStatus.WAIT;
 
 @RequiredArgsConstructor
 @Service
@@ -112,13 +113,13 @@ public class InquiryService {
      */
     @Transactional
     public void update(
+            final long inquiryId,
             final UpdateInquiryRequest request
     ) {
-        Inquiry inquiry = inquiryRepository.findById(request.inquiryId())
-                .orElseThrow(() -> new InquiryException.InquiryNotFoundException(request.inquiryId()));
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new InquiryException.InquiryNotFoundException(inquiryId));
 
-        inquiry.updateAnswer(request.inquiryAnswer());
-        inquiry.updateInquiryStatus(COMPLETE);
+        inquiry.updateInquiry(request);
     }
 
     /**
@@ -129,6 +130,6 @@ public class InquiryService {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new InquiryException.InquiryNotFoundException(inquiryId));
 
-        inquiry.updateInquiryStatus(DELETION);
+        inquiryRepository.delete(inquiry);
     }
 }

--- a/src/main/java/com/coverflow/inquiry/domain/Inquiry.java
+++ b/src/main/java/com/coverflow/inquiry/domain/Inquiry.java
@@ -2,6 +2,7 @@ package com.coverflow.inquiry.domain;
 
 import com.coverflow.global.entity.BaseTimeEntity;
 import com.coverflow.inquiry.dto.request.SaveInquiryRequest;
+import com.coverflow.inquiry.dto.request.UpdateInquiryRequest;
 import com.coverflow.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -43,6 +44,11 @@ public class Inquiry extends BaseTimeEntity {
         this.member = Member.builder()
                 .id(UUID.fromString(memberId))
                 .build();
+    }
+
+    public void updateInquiry(final UpdateInquiryRequest request) {
+        this.answer = request.inquiryAnswer();
+        this.inquiryStatus = InquiryStatus.valueOf(request.inquiryStatus());
     }
 
     public void updateAnswer(final String answer) {

--- a/src/main/java/com/coverflow/inquiry/dto/request/UpdateInquiryRequest.java
+++ b/src/main/java/com/coverflow/inquiry/dto/request/UpdateInquiryRequest.java
@@ -1,12 +1,12 @@
 package com.coverflow.inquiry.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 
 public record UpdateInquiryRequest(
-        @Positive
-        long inquiryId,
+
         @NotBlank
-        String inquiryAnswer
+        String inquiryAnswer,
+        @NotBlank
+        String inquiryStatus
 ) {
 }

--- a/src/main/java/com/coverflow/inquiry/presentation/InquiryController.java
+++ b/src/main/java/com/coverflow/inquiry/presentation/InquiryController.java
@@ -85,13 +85,14 @@ public class InquiryController {
                         .build());
     }
 
-    @PutMapping("/admin")
+    @PatchMapping("/admin/{inquiryId}")
     @AdminAuthorize
     public ResponseEntity<ResponseHandler<Void>> update(
+            @PathVariable @Positive final long inquiryId,
             @RequestBody @Valid final UpdateInquiryRequest request
     ) {
         BadwordUtil.check(request.inquiryAnswer());
-        inquiryService.update(request);
+        inquiryService.update(inquiryId, request);
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/coverflow/member/presentation/MemberController.java
+++ b/src/main/java/com/coverflow/member/presentation/MemberController.java
@@ -77,7 +77,7 @@ public class MemberController {
                         .build());
     }
 
-    @PutMapping
+    @PatchMapping
     @MemberAuthorize
     public ResponseEntity<ResponseHandler<UpdateNicknameResponse>> update(
             @AuthenticationPrincipal final UserDetails userDetails

--- a/src/main/java/com/coverflow/notification/presentation/NotificationController.java
+++ b/src/main/java/com/coverflow/notification/presentation/NotificationController.java
@@ -52,7 +52,7 @@ public class NotificationController {
 //                );
 //    }
 
-    @PutMapping
+    @PatchMapping
     public ResponseEntity<ResponseHandler<Void>> update(
             @RequestBody @Valid final List<UpdateNotificationRequest> requests
     ) {

--- a/src/main/java/com/coverflow/question/application/AnswerService.java
+++ b/src/main/java/com/coverflow/question/application/AnswerService.java
@@ -139,9 +139,12 @@ public class AnswerService {
      * [답변 채택 메서드]
      */
     @Transactional
-    public void choose(final UpdateSelectionRequest request) {
-        Answer answer = answerRepository.findById(request.answerId())
-                .orElseThrow(() -> new AnswerException.AnswerNotFoundException(request.answerId()));
+    public void choose(
+            final long answerId,
+            final UpdateSelectionRequest request
+    ) {
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerException.AnswerNotFoundException(answerId));
         Member member = memberRepository.findById(answer.getMember().getId())
                 .orElseThrow(() -> new MemberException.MemberNotFoundException(answer.getMember().getId()));
 
@@ -154,11 +157,14 @@ public class AnswerService {
      * [관리자 전용: 답변 수정 메서드]
      */
     @Transactional
-    public void update(final UpdateAnswerRequest request) {
-        Answer answer = answerRepository.findById(request.answerId())
-                .orElseThrow(() -> new AnswerException.AnswerNotFoundException(request.answerId()));
+    public void update(
+            final long answerId,
+            final UpdateAnswerRequest request
+    ) {
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerException.AnswerNotFoundException(answerId));
 
-        answer.updateAnswer(new Answer(request.content()));
+        answer.updateAnswer(request);
     }
 
     /**
@@ -169,6 +175,6 @@ public class AnswerService {
         Answer answer = answerRepository.findById(answerId)
                 .orElseThrow(() -> new AnswerException.AnswerNotFoundException(answerId));
 
-        answer.updateAnswerStatus(AnswerStatus.DELETION);
+        answerRepository.delete(answer);
     }
 }

--- a/src/main/java/com/coverflow/question/application/QuestionService.java
+++ b/src/main/java/com/coverflow/question/application/QuestionService.java
@@ -153,11 +153,14 @@ public class QuestionService {
      * [질문 수정 메서드]
      */
     @Transactional
-    public void update(final UpdateQuestionRequest request) {
-        Question question = questionRepository.findById(request.questionId())
-                .orElseThrow(() -> new QuestionException.QuestionNotFoundException(request.questionId()));
+    public void update(
+            final long questionId,
+            final UpdateQuestionRequest request
+    ) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionException.QuestionNotFoundException(questionId));
 
-        question.updateQuestion(new Question(request));
+        question.updateQuestion(request);
     }
 
     /**
@@ -168,6 +171,6 @@ public class QuestionService {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionException.QuestionNotFoundException(questionId));
 
-        question.updateQuestionStatus(QuestionStatus.DELETION);
+        questionRepository.delete(question);
     }
 }

--- a/src/main/java/com/coverflow/question/domain/Answer.java
+++ b/src/main/java/com/coverflow/question/domain/Answer.java
@@ -3,6 +3,7 @@ package com.coverflow.question.domain;
 import com.coverflow.global.entity.BaseTimeEntity;
 import com.coverflow.member.domain.Member;
 import com.coverflow.question.dto.request.SaveAnswerRequest;
+import com.coverflow.question.dto.request.UpdateAnswerRequest;
 import com.coverflow.report.domain.Report;
 import jakarta.persistence.*;
 import lombok.*;
@@ -42,10 +43,6 @@ public class Answer extends BaseTimeEntity {
     @OneToMany(mappedBy = "answer", fetch = FetchType.LAZY)
     private List<Report> reports = new ArrayList<>(); // 답변에 대한 신고 리스트
 
-    public Answer(final String content) {
-        this.content = content;
-    }
-
     public Answer(
             final SaveAnswerRequest request,
             final String memberId
@@ -61,8 +58,9 @@ public class Answer extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateAnswer(final Answer answer) {
-        this.content = answer.getContent();
+    public void updateAnswer(final UpdateAnswerRequest request) {
+        this.content = request.content();
+        this.answerStatus = AnswerStatus.valueOf(request.answerStatus());
     }
 
     public void updateSelection(final boolean selection) {

--- a/src/main/java/com/coverflow/question/domain/Question.java
+++ b/src/main/java/com/coverflow/question/domain/Question.java
@@ -83,9 +83,10 @@ public class Question extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateQuestion(final Question question) {
-        this.title = question.getTitle();
-        this.content = question.getContent();
+    public void updateQuestion(final UpdateQuestionRequest request) {
+        this.title = request.title();
+        this.content = request.content();
+        this.questionStatus = QuestionStatus.valueOf(request.questionStatus());
     }
 
     public void updateViewCount(int viewCount) {

--- a/src/main/java/com/coverflow/question/dto/request/UpdateAnswerRequest.java
+++ b/src/main/java/com/coverflow/question/dto/request/UpdateAnswerRequest.java
@@ -1,12 +1,12 @@
 package com.coverflow.question.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 
 public record UpdateAnswerRequest(
-        @Positive
-        long answerId,
+
         @NotBlank
-        String content
+        String content,
+        @NotBlank
+        String answerStatus
 ) {
 }

--- a/src/main/java/com/coverflow/question/dto/request/UpdateQuestionRequest.java
+++ b/src/main/java/com/coverflow/question/dto/request/UpdateQuestionRequest.java
@@ -1,14 +1,14 @@
 package com.coverflow.question.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 
 public record UpdateQuestionRequest(
-        @Positive
-        long questionId,
+
         @NotBlank
         String title,
         @NotBlank
-        String content
+        String content,
+        @NotBlank
+        String questionStatus
 ) {
 }

--- a/src/main/java/com/coverflow/question/dto/request/UpdateSelectionRequest.java
+++ b/src/main/java/com/coverflow/question/dto/request/UpdateSelectionRequest.java
@@ -1,11 +1,8 @@
 package com.coverflow.question.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 
 public record UpdateSelectionRequest(
-        @Positive
-        long answerId,
         @NotBlank
         boolean selection
 ) {

--- a/src/main/java/com/coverflow/question/presentation/AnswerController.java
+++ b/src/main/java/com/coverflow/question/presentation/AnswerController.java
@@ -89,25 +89,27 @@ public class AnswerController {
                         .build());
     }
 
-    @PutMapping("/selection")
+    @PatchMapping("/selection/{answerId}")
     @MemberAuthorize
     public ResponseEntity<ResponseHandler<Void>> choose(
+            @PathVariable @Positive final long answerId,
             @RequestBody @Valid final UpdateSelectionRequest request
     ) {
-        answerService.choose(request);
+        answerService.choose(answerId, request);
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.NO_CONTENT)
                         .build());
     }
 
-    @PutMapping("/admin")
+    @PatchMapping("/admin/{answerId}")
     @AdminAuthorize
     public ResponseEntity<ResponseHandler<Void>> update(
+            @PathVariable @Positive final long answerId,
             @RequestBody @Valid final UpdateAnswerRequest request
     ) {
         BadwordUtil.check(request.content());
-        answerService.update(request);
+        answerService.update(answerId, request);
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/coverflow/question/presentation/QuestionController.java
+++ b/src/main/java/com/coverflow/question/presentation/QuestionController.java
@@ -105,14 +105,15 @@ public class QuestionController {
                         .build());
     }
 
-    @PutMapping
+    @PatchMapping("/{questionId}")
     @MemberAuthorize
     public ResponseEntity<ResponseHandler<Void>> update(
+            @PathVariable @Positive final long questionId,
             @RequestBody @Valid final UpdateQuestionRequest request
     ) {
         BadwordUtil.check(request.title());
         BadwordUtil.check(request.content());
-        questionService.update(request);
+        questionService.update(questionId, request);
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/coverflow/report/application/ReportService.java
+++ b/src/main/java/com/coverflow/report/application/ReportService.java
@@ -8,6 +8,7 @@ import com.coverflow.report.domain.Report;
 import com.coverflow.report.domain.ReportStatus;
 import com.coverflow.report.dto.ReportDTO;
 import com.coverflow.report.dto.request.SaveReportRequest;
+import com.coverflow.report.dto.request.UpdateReportRequest;
 import com.coverflow.report.dto.response.FindReportResponse;
 import com.coverflow.report.exception.ReportException;
 import com.coverflow.report.infrastructure.ReportRepository;
@@ -112,6 +113,20 @@ public class ReportService {
     }
 
     /**
+     * [관리자: 신고 수정 메서드]
+     */
+    @Transactional
+    public void update(
+            final long reportId,
+            final UpdateReportRequest request
+    ) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException.ReportNotFoundException(reportId));
+
+        report.updateReport(request);
+    }
+
+    /**
      * [관리자 전용: 신고 삭제 메서드]
      */
     @Transactional
@@ -119,6 +134,6 @@ public class ReportService {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportException.ReportNotFoundException(reportId));
 
-        report.updateReportStatus(ReportStatus.DELETION);
+        reportRepository.delete(report);
     }
 }

--- a/src/main/java/com/coverflow/report/domain/Report.java
+++ b/src/main/java/com/coverflow/report/domain/Report.java
@@ -5,6 +5,7 @@ import com.coverflow.member.domain.Member;
 import com.coverflow.question.domain.Answer;
 import com.coverflow.question.domain.Question;
 import com.coverflow.report.dto.request.SaveReportRequest;
+import com.coverflow.report.dto.request.UpdateReportRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -73,7 +74,7 @@ public class Report extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateReportStatus(final ReportStatus reportStatus) {
-        this.reportStatus = reportStatus;
+    public void updateReport(final UpdateReportRequest request) {
+        this.reportStatus = ReportStatus.valueOf(request.updateStatus());
     }
 }

--- a/src/main/java/com/coverflow/report/dto/request/UpdateReportRequest.java
+++ b/src/main/java/com/coverflow/report/dto/request/UpdateReportRequest.java
@@ -1,0 +1,10 @@
+package com.coverflow.report.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateReportRequest(
+
+        @NotBlank
+        String updateStatus
+) {
+}

--- a/src/main/java/com/coverflow/report/presentation/ReportController.java
+++ b/src/main/java/com/coverflow/report/presentation/ReportController.java
@@ -7,6 +7,7 @@ import com.coverflow.global.util.BadwordUtil;
 import com.coverflow.report.application.ReportService;
 import com.coverflow.report.domain.ReportStatus;
 import com.coverflow.report.dto.request.SaveReportRequest;
+import com.coverflow.report.dto.request.UpdateReportRequest;
 import com.coverflow.report.dto.response.FindReportResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -79,6 +80,19 @@ public class ReportController {
         return ResponseEntity.ok()
                 .body(ResponseHandler.<Void>builder()
                         .statusCode(HttpStatus.CREATED)
+                        .build());
+    }
+
+    @PatchMapping("/admin/{reportId}")
+    @AdminAuthorize
+    public ResponseEntity<ResponseHandler<Void>> update(
+            @PathVariable @Positive final long reportId,
+            @RequestBody @Valid final UpdateReportRequest request
+    ) {
+        reportService.update(reportId, request);
+        return ResponseEntity.ok()
+                .body(ResponseHandler.<Void>builder()
+                        .statusCode(HttpStatus.NO_CONTENT)
                         .build());
     }
 


### PR DESCRIPTION
# ✨(#이슈 번호)
- closed #170 

# ✏️내용
- 로그아웃, 토큰 예외 처리 빠진 부분 추가로 구현했습니다.

- 삭제도 patch로 하는 이유
  -> 데이터를 직접 삭제하는 api를 아예 delete로 바꿨습니다.

- 기업 수정 API
기존: put/patch/delete(상태만 삭제)
변경: patch로 통일

- 문의 수정 API
기존: put/delete(상태만 삭제)
변경: patch로 통일

- 회원 수정 API
기존: put
변경: patch

- 알림 수정 API
기존: put
변경: patch

- 질문 수정/삭제 API
기존: put/delete(상태만 삭제)
변경: patch

- 답변 채택
기존: put
변경: patch

- 답변 수정/삭제 API
기존: put/delete(상태만 삭제)
변경: patch

- 신고 수정/삭제 API
기존: put/delete(상태만 삭제)
변경: patch