### PR TITLE
[Feature] - [Company] 기업 검색 로직 리팩토링했습니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 ## 🚀 기술 스택
-![image](https://github.com/COFLLL/CoverFlow-BE/assets/98208452/4d2492f0-36dc-4c61-8078-c1a5907b84b9)
+![image](https://github.com/fakerdeft/CoverFlow-BE/assets/98208452/cc5dffb8-d84e-48c6-869a-8adc5c2c5baf)
 
 ## 🚀 프로젝트 아키텍처
 ![image](https://github.com/COFLLL/.github/assets/98208452/bdd1c678-3eef-4af7-a75e-661069930261)

--- a/src/main/java/com/coverflow/company/application/CompanyService.java
+++ b/src/main/java/com/coverflow/company/application/CompanyService.java
@@ -56,6 +56,7 @@ public class CompanyService {
         );
     }
 
+    @Transactional(readOnly = true)
     public SearchCompanyCountResponse search(final String name) {
         long totalElements = companyRepository.countByName(name);
         int totalPages = (int) (totalElements / NORMAL_PAGE_SIZE);

--- a/src/main/java/com/coverflow/company/application/CompanyService.java
+++ b/src/main/java/com/coverflow/company/application/CompanyService.java
@@ -56,7 +56,7 @@ public class CompanyService {
         );
     }
 
-    public SearchCompanyCountResponse searchTotalCount(final String name) {
+    public SearchCompanyCountResponse search(final String name) {
         long totalElements = companyRepository.countByName(name);
         int totalPages = (int) (totalElements / NORMAL_PAGE_SIZE);
 

--- a/src/main/java/com/coverflow/company/dto/response/SearchCompanyCountResponse.java
+++ b/src/main/java/com/coverflow/company/dto/response/SearchCompanyCountResponse.java
@@ -1,0 +1,13 @@
+package com.coverflow.company.dto.response;
+
+public record SearchCompanyCountResponse(
+        int totalPages,
+        long totalElements
+) {
+    public static SearchCompanyCountResponse of(
+            final int totalPages,
+            final long totalElements
+    ) {
+        return new SearchCompanyCountResponse(totalPages, totalElements);
+    }
+}

--- a/src/main/java/com/coverflow/company/dto/response/SearchCompanyResponse.java
+++ b/src/main/java/com/coverflow/company/dto/response/SearchCompanyResponse.java
@@ -5,16 +5,11 @@ import com.coverflow.company.dto.CompanyDTO;
 import java.util.List;
 
 public record SearchCompanyResponse(
-        int totalPages,
-        long totalElements,
+
         List<CompanyDTO> companyList
 ) {
 
-    public static SearchCompanyResponse of(
-            final int totalPages,
-            final long totalElements,
-            final List<CompanyDTO> companyList
-    ) {
-        return new SearchCompanyResponse(totalPages, totalElements, companyList);
+    public static SearchCompanyResponse from(final List<CompanyDTO> companyList) {
+        return new SearchCompanyResponse(companyList);
     }
 }

--- a/src/main/java/com/coverflow/company/infrastructure/CompanyCustomRepository.java
+++ b/src/main/java/com/coverflow/company/infrastructure/CompanyCustomRepository.java
@@ -4,10 +4,15 @@ import com.coverflow.company.domain.Company;
 import com.coverflow.company.dto.request.FindCompanyAdminRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
 public interface CompanyCustomRepository {
+
+    Optional<Slice<Company>> findByNameStartingWith(final Pageable pageable, final String name);
+
+    Long countByName(final String name);
 
     Optional<Page<Company>> findWithFilters(final Pageable pageable, final FindCompanyAdminRequest request);
 }

--- a/src/main/java/com/coverflow/company/infrastructure/CompanyRepository.java
+++ b/src/main/java/com/coverflow/company/infrastructure/CompanyRepository.java
@@ -1,8 +1,6 @@
 package com.coverflow.company.infrastructure;
 
 import com.coverflow.company.domain.Company;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,17 +10,6 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CompanyRepository extends JpaRepository<Company, Long>, CompanyCustomRepository {
-
-    @Query("""
-            SELECT c
-            FROM Company c
-            WHERE c.name LIKE :name%
-            AND c.companyStatus = 'REGISTRATION'
-            """)
-    Optional<Page<Company>> findByNameStartingWithAndCompanyStatus(
-            final Pageable pageable,
-            @Param("name") final String name
-    );
 
     Optional<Company> findByName(final String name);
 

--- a/src/main/java/com/coverflow/company/presentation/CompanyController.java
+++ b/src/main/java/com/coverflow/company/presentation/CompanyController.java
@@ -6,6 +6,7 @@ import com.coverflow.company.dto.request.SaveCompanyRequest;
 import com.coverflow.company.dto.request.UpdateCompanyRequest;
 import com.coverflow.company.dto.response.FindAllCompaniesResponse;
 import com.coverflow.company.dto.response.FindCompanyResponse;
+import com.coverflow.company.dto.response.SearchCompanyCountResponse;
 import com.coverflow.company.dto.response.SearchCompanyResponse;
 import com.coverflow.global.annotation.AdminAuthorize;
 import com.coverflow.global.handler.ResponseHandler;
@@ -28,12 +29,22 @@ public class CompanyController {
     @GetMapping
     public ResponseEntity<ResponseHandler<SearchCompanyResponse>> search(
             @RequestParam @PositiveOrZero final int pageNo,
-            @RequestParam(defaultValue = "name") final String name
+            @RequestParam final String name
     ) {
         return ResponseEntity.ok()
                 .body(ResponseHandler.<SearchCompanyResponse>builder()
                         .statusCode(HttpStatus.OK)
                         .data(companyService.search(pageNo, name))
+                        .build()
+                );
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<ResponseHandler<SearchCompanyCountResponse>> search(@RequestParam final String name) {
+        return ResponseEntity.ok()
+                .body(ResponseHandler.<SearchCompanyCountResponse>builder()
+                        .statusCode(HttpStatus.OK)
+                        .data(companyService.search(name))
                         .build()
                 );
     }

--- a/src/main/java/com/coverflow/global/util/PageUtil.java
+++ b/src/main/java/com/coverflow/global/util/PageUtil.java
@@ -9,7 +9,7 @@ public class PageUtil {
     public static Pageable generatePageAsc(
             final int pageNo,
             final int pageSize,
-            final String criterion
+            final String... criterion
     ) {
         return PageRequest.of(pageNo, pageSize, Sort.by(criterion).ascending());
     }

--- a/src/main/java/com/coverflow/question/application/QuestionService.java
+++ b/src/main/java/com/coverflow/question/application/QuestionService.java
@@ -22,7 +22,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static com.coverflow.company.exception.CompanyException.CompanyNotFoundException;
-import static com.coverflow.global.constant.Constant.*;
+import static com.coverflow.global.constant.Constant.LARGE_PAGE_SIZE;
+import static com.coverflow.global.constant.Constant.NORMAL_PAGE_SIZE;
 import static com.coverflow.global.util.PageUtil.generatePageDesc;
 import static com.coverflow.question.exception.QuestionException.QuestionNotFoundException;
 
@@ -64,7 +65,7 @@ public class QuestionService {
             final String criterion,
             final UUID memberId
     ) {
-        Page<Question> questionList = questionRepository.findRegisteredQuestions(generatePageDesc(pageNo, SMALL_PAGE_SIZE, criterion), memberId)
+        Page<Question> questionList = questionRepository.findRegisteredQuestions(generatePageDesc(pageNo, NORMAL_PAGE_SIZE, criterion), memberId)
                 .orElseThrow(() -> new QuestionNotFoundException(memberId));
 
         return FindMyQuestionsResponse.of(


### PR DESCRIPTION
# ✨(#이슈 번호)
- closed #222 

# ✏️내용
기업 검색 시
검색 API 하나로 전체 페이지 수, 전체 기업 수, 전체 기업 목록이 전부 응답됐었는데
목록 조회 쿼리 + count 쿼리로 두 개가 한 트랜잭션에 포함되니 검색 속도가 현저히 떨어지는 것을 확인했습니다.
따라서 기업 목록 검색 API와 전체 페이지/기업 수 검색 API로 분리하게 되었습니다.